### PR TITLE
fix: cast entry ids to string for eloquent driver compatibility

### DIFF
--- a/src/Facades/Occurrences.php
+++ b/src/Facades/Occurrences.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static Collection<int, OccurrenceData> on(Carbon $date)
  * @method static Collection<int, OccurrenceData> between(Carbon $from, Carbon $to)
  * @method static Collection<int, OccurrenceData> forEntry(string|int $entryId)
- * @method static Collection<int, OccurrenceData> forOrganizer(?string $organizerId)
+ * @method static Collection<int, OccurrenceData> forOrganizer(string|int|null $organizerId)
  * @method static Collection<int, OccurrenceData> upcoming(int $limit = 10)
  * @method static void rebuild()
  * @method static void clear()

--- a/src/Facades/Occurrences.php
+++ b/src/Facades/Occurrences.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static Collection<int, OccurrenceData> all()
  * @method static Collection<int, OccurrenceData> on(Carbon $date)
  * @method static Collection<int, OccurrenceData> between(Carbon $from, Carbon $to)
- * @method static Collection<int, OccurrenceData> forEntry(string $entryId)
+ * @method static Collection<int, OccurrenceData> forEntry(string|int $entryId)
  * @method static Collection<int, OccurrenceData> forOrganizer(?string $organizerId)
  * @method static Collection<int, OccurrenceData> upcoming(int $limit = 10)
  * @method static void rebuild()

--- a/src/Occurrences/OccurrenceCache.php
+++ b/src/Occurrences/OccurrenceCache.php
@@ -62,8 +62,10 @@ class OccurrenceCache
     /**
      * @return Collection<int, OccurrenceData>
      */
-    public function forOrganizer(?string $organizerId): Collection
+    public function forOrganizer(string|int|null $organizerId): Collection
     {
+        $organizerId = $organizerId !== null ? (string) $organizerId : null;
+
         return $this->all()->filter(
             fn (OccurrenceData $o) => $o->organizerId === $organizerId
         )->values();
@@ -187,8 +189,8 @@ class OccurrenceCache
             return $nullOrganizer;
         }
 
-        if (is_string($organizer)) {
-            $organizer = Entry::find($organizer);
+        if (is_string($organizer) || is_int($organizer)) {
+            $organizer = Entry::find((string) $organizer);
             if (! $organizer) {
                 return array_merge($nullOrganizer, ['id' => (string) $entry->get((string) $handle)]);
             }

--- a/src/Occurrences/OccurrenceCache.php
+++ b/src/Occurrences/OccurrenceCache.php
@@ -50,8 +50,10 @@ class OccurrenceCache
     /**
      * @return Collection<int, OccurrenceData>
      */
-    public function forEntry(string $entryId): Collection
+    public function forEntry(string|int $entryId): Collection
     {
+        $entryId = (string) $entryId;
+
         return $this->all()->filter(
             fn (OccurrenceData $o) => $o->entryId === $entryId
         )->values();
@@ -120,12 +122,13 @@ class OccurrenceCache
 
             $eventOccurrences = $resolver->resolve($entry, $eventFrom, $to);
 
+            $entryId = (string) $entry->id();
             $organizerData = $this->extractOrganizerData($entry);
 
             foreach ($eventOccurrences as $occurrence) {
                 $occurrences->push([
-                    'id' => $entry->id().'-'.$occurrence->start->format('Y-m-d-His'),
-                    'entry_id' => $entry->id(),
+                    'id' => $entryId.'-'.$occurrence->start->format('Y-m-d-His'),
+                    'entry_id' => $entryId,
                     'title' => (string) $entry->get('title'),
                     'slug' => $entry->slug(),
                     'teaser' => $this->extractTeaser($entry),
@@ -187,13 +190,13 @@ class OccurrenceCache
         if (is_string($organizer)) {
             $organizer = Entry::find($organizer);
             if (! $organizer) {
-                return array_merge($nullOrganizer, ['id' => $entry->get((string) $handle)]);
+                return array_merge($nullOrganizer, ['id' => (string) $entry->get((string) $handle)]);
             }
         }
 
         if (is_object($organizer) && method_exists($organizer, 'id') && method_exists($organizer, 'slug')) {
             return [
-                'id' => $organizer->id(),
+                'id' => (string) $organizer->id(),
                 'slug' => $organizer->slug(),
                 'title' => $organizer->get('title'),
                 'url' => $organizer->url(),

--- a/src/Occurrences/OccurrenceData.php
+++ b/src/Occurrences/OccurrenceData.php
@@ -37,12 +37,12 @@ readonly class OccurrenceData
     public static function fromArray(array $data): self
     {
         return new self(
-            id: $data['id'],
-            entryId: $data['entry_id'],
+            id: (string) $data['id'],
+            entryId: (string) $data['entry_id'],
             title: $data['title'],
             slug: $data['slug'],
             teaser: $data['teaser'] ?? null,
-            organizerId: $data['organizer_id'] ?? null,
+            organizerId: isset($data['organizer_id']) ? (string) $data['organizer_id'] : null,
             organizerSlug: $data['organizer_slug'] ?? null,
             organizerTitle: $data['organizer_title'] ?? null,
             organizerUrl: $data['organizer_url'] ?? null,

--- a/src/Tags/Calendar.php
+++ b/src/Tags/Calendar.php
@@ -56,7 +56,7 @@ class Calendar extends Tags
             $entryId = $entryId->value();
         }
 
-        $entry = is_string($entryId) ? Entry::find($entryId) : null;
+        $entry = (is_string($entryId) || is_int($entryId)) ? Entry::find((string) $entryId) : null;
 
         if (! $entry || ! $dateString) {
             return '';
@@ -89,7 +89,7 @@ class Calendar extends Tags
         $limit = $this->params->int('limit', 5);
         $from = Carbon::now();
 
-        return Occurrences::forOrganizer(is_string($organizerId) ? $organizerId : null)
+        return Occurrences::forOrganizer((is_string($organizerId) || is_int($organizerId)) ? (string) $organizerId : null)
             ->filter(fn (OccurrenceData $o) => $o->start->gte($from))
             ->sortBy(fn (OccurrenceData $o) => $o->start)
             ->take($limit)
@@ -175,7 +175,7 @@ class Calendar extends Tags
     public function nextOccurrences(): array
     {
         $entryId = $this->params->get('entry') ?? $this->context->get('id');
-        $entry = is_string($entryId) ? Entry::find($entryId) : null;
+        $entry = (is_string($entryId) || is_int($entryId)) ? Entry::find((string) $entryId) : null;
 
         if (! $entry) {
             return [];

--- a/tests/Unit/OccurrenceDataTest.php
+++ b/tests/Unit/OccurrenceDataTest.php
@@ -32,3 +32,27 @@ test('OccurrenceData can be created from array and serialized back', function ()
     expect($occurrence->tags)->toBe(['music']);
     expect($array['id'])->toBe('abc-123-2026-03-06-150000');
 });
+
+test('OccurrenceData normalizes numeric ids to strings', function () {
+    $occurrence = OccurrenceData::fromArray([
+        'id' => '1-2026-03-06-150000',
+        'entry_id' => 1,
+        'title' => 'Numeric IDs',
+        'slug' => 'numeric-ids',
+        'teaser' => null,
+        'organizer_id' => 2,
+        'organizer_slug' => null,
+        'organizer_title' => null,
+        'organizer_url' => null,
+        'tags' => [],
+        'start' => '2026-03-06T15:00:00+00:00',
+        'end' => null,
+        'is_all_day' => false,
+        'is_recurring' => false,
+        'recurrence_description' => null,
+        'url' => '/events/numeric-ids',
+    ]);
+
+    expect($occurrence->entryId)->toBe('1')
+        ->and($occurrence->organizerId)->toBe('2');
+});


### PR DESCRIPTION
Closes #8

`$entry->id()` returns int under `statamic/eloquent-driver` and string under flat-file. `OccurrenceData` contracts on `string`, so rebuild crashed with TypeError.

- Normalize at write boundary (`OccurrenceCache::rebuild`, `extractOrganizerData`)
- Normalize at read boundary (`OccurrenceData::fromArray`) — also protects stale caches
- Relax `forEntry()` to `string|int` so consumers don't carry the quirk