### PR TITLE
fix: expose composed occurrence_id in calendar loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The addon exposes an .ics feed that calendar apps (Apple Calendar, Google Calend
 
 {{-- Per-event download inside a calendar loop --}}
 {{ calendar from="now" limit="10" }}
-  <a href="{{ calendar:ics_download_url :occurrence_id="id" }}">
+  <a href="{{ calendar:ics_download_url }}">
     Add to calendar
   </a>
 {{ /calendar }}
@@ -329,13 +329,13 @@ Returns the .ics download URL for a single occurrence. Use inside any `{{ calend
 ```antlers
 {{ calendar from="now" limit="10" }}
   <h2>{{ title }}</h2>
-  <a href="{{ calendar:ics_download_url :occurrence_id="id" }}">Add to calendar</a>
+  <a href="{{ calendar:ics_download_url }}">Add to calendar</a>
 {{ /calendar }}
 ```
 
-| Parameter      | Description  | Default              |
-| -------------- | ------------ | -------------------- |
-| `occurrence_id` | Occurrence ID (`{entry_id}-{Y-m-d-His}`) | current context `id` |
+| Parameter       | Description                                | Default                                  |
+| --------------- | ------------------------------------------ | ---------------------------------------- |
+| `occurrence_id` | Occurrence ID (`{entry_id}-{Y-m-d-His}`)   | context `occurrence_id`, else `id`       |
 
 ### `{{ calendar:for_organizer }}`
 

--- a/src/Occurrences/OccurrenceCache.php
+++ b/src/Occurrences/OccurrenceCache.php
@@ -129,7 +129,7 @@ class OccurrenceCache
 
             foreach ($eventOccurrences as $occurrence) {
                 $occurrences->push([
-                    'id' => $entryId.'-'.$occurrence->start->format('Y-m-d-His'),
+                    'id' => OccurrenceData::composeId($entryId, $occurrence->start),
                     'entry_id' => $entryId,
                     'title' => (string) $entry->get('title'),
                     'slug' => $entry->slug(),

--- a/src/Occurrences/OccurrenceData.php
+++ b/src/Occurrences/OccurrenceData.php
@@ -34,6 +34,15 @@ readonly class OccurrenceData
         public string $url,
     ) {}
 
+    /**
+     * Composes the stable occurrence id used for .ics downloads and cache
+     * keys. Single source of truth — all call sites go through this.
+     */
+    public static function composeId(string|int $entryId, Carbon $start): string
+    {
+        return ((string) $entryId).'-'.$start->format('Y-m-d-His');
+    }
+
     public static function fromArray(array $data): self
     {
         return new self(

--- a/src/Tags/Calendar.php
+++ b/src/Tags/Calendar.php
@@ -70,7 +70,7 @@ class Calendar extends Tags
         }
 
         return $this->parse([
-            'occurrence_id' => $entry->id().'-'.$occurrence->start->format('Y-m-d-His'),
+            'occurrence_id' => OccurrenceData::composeId($entry->id(), $occurrence->start),
             'start' => $occurrence->start,
             'end' => $occurrence->end,
             'is_all_day' => $occurrence->isAllDay,
@@ -386,7 +386,7 @@ class Calendar extends Tags
         $augmented = $occurrence->entry->toAugmentedArray();
 
         return array_merge($augmented, [
-            'occurrence_id' => $occurrence->entry->id().'-'.$occurrence->start->format('Y-m-d-His'),
+            'occurrence_id' => OccurrenceData::composeId($occurrence->entry->id(), $occurrence->start),
             'start' => $occurrence->start,
             'end' => $occurrence->end,
             'is_all_day' => $occurrence->isAllDay,

--- a/src/Tags/Calendar.php
+++ b/src/Tags/Calendar.php
@@ -111,14 +111,22 @@ class Calendar extends Tags
     /**
      * Returns the .ics download URL for a single occurrence.
      *
-     * Usage: {{ calendar:ics_download_url :occurrence_id="id" }}
+     * Usage (inside `{{ calendar }}` or `{{ calendar:current_occurrence }}`):
+     *   {{ calendar:ics_download_url }}
      *
-     * The occurrence ID follows the format "{entry_id}-{Y-m-d-His}",
-     * which is available as `id` in any `{{ calendar }}` loop.
+     * Or explicit:
+     *   {{ calendar:ics_download_url :occurrence_id="occurrence_id" }}
+     *
+     * The occurrence ID follows the format "{entry_id}-{Y-m-d-His}" and is
+     * exposed as `occurrence_id` in loop items and current_occurrence context.
      */
     public function icsDownloadUrl(): string
     {
-        $id = (string) ($this->params->get('occurrence_id') ?? $this->context->get('id'));
+        $id = (string) (
+            $this->params->get('occurrence_id')
+            ?? $this->context->get('occurrence_id')
+            ?? $this->context->get('id')
+        );
 
         return URL::route('statamic-calendar.ics.download', $id);
     }
@@ -378,6 +386,7 @@ class Calendar extends Tags
         $augmented = $occurrence->entry->toAugmentedArray();
 
         return array_merge($augmented, [
+            'occurrence_id' => $occurrence->entry->id().'-'.$occurrence->start->format('Y-m-d-His'),
             'start' => $occurrence->start,
             'end' => $occurrence->end,
             'is_all_day' => $occurrence->isAllDay,
@@ -391,6 +400,7 @@ class Calendar extends Tags
     {
         return [
             'id' => $occurrence->entryId,
+            'occurrence_id' => $occurrence->id,
             'title' => $occurrence->title,
             'slug' => $occurrence->slug,
             'teaser' => $occurrence->teaser,

--- a/tests/Feature/CalendarTagTest.php
+++ b/tests/Feature/CalendarTagTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use ElSchneider\StatamicCalendar\Occurrences\OccurrenceCache;
+use ElSchneider\StatamicCalendar\Occurrences\OccurrenceData;
+use ElSchneider\StatamicCalendar\Tags\Calendar;
+use Statamic\Contracts\View\Antlers\Parser;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-02-01 00:00:00');
+
+    $this->tagOccurrences = collect([
+        OccurrenceData::fromArray([
+            'id' => 'aaa-2026-02-05-100000',
+            'entry_id' => 'aaa',
+            'title' => 'Event A',
+            'slug' => 'event-a',
+            'teaser' => null,
+            'organizer_id' => null,
+            'organizer_slug' => null,
+            'organizer_title' => null,
+            'organizer_url' => null,
+            'tags' => [],
+            'start' => '2026-02-05T10:00:00+00:00',
+            'end' => '2026-02-05T11:00:00+00:00',
+            'is_all_day' => false,
+            'is_recurring' => false,
+            'recurrence_description' => null,
+            'url' => '/events/event-a',
+        ]),
+    ]);
+
+    $mock = Mockery::mock(OccurrenceCache::class);
+    $mock->shouldReceive('all')->andReturn($this->tagOccurrences);
+    $this->app->instance(OccurrenceCache::class, $mock);
+});
+
+afterEach(fn () => Carbon::setTestNow());
+
+function calendarTag(array $params = [], array $context = []): Calendar
+{
+    $tag = app(Calendar::class);
+    $tag->setProperties([
+        'parser' => app(Parser::class),
+        'content' => '',
+        'context' => $context,
+        'params' => $params,
+        'tag' => 'calendar',
+        'tag_method' => 'index',
+    ]);
+
+    return $tag;
+}
+
+test('loop items expose composed occurrence_id alongside entry id', function () {
+    $result = calendarTag(['from' => '2026-02-01'])->index();
+
+    $item = collect($result)->first();
+
+    expect($item['id'])->toBe('aaa');
+    expect($item['occurrence_id'])->toBe('aaa-2026-02-05-100000');
+});
+
+test('ics_download_url uses context occurrence_id when present', function () {
+    $tag = calendarTag(
+        params: [],
+        context: ['id' => 'aaa', 'occurrence_id' => 'aaa-2026-02-05-100000']
+    );
+
+    expect($tag->icsDownloadUrl())->toContain('aaa-2026-02-05-100000');
+});
+
+test('ics_download_url falls back to context id when occurrence_id absent', function () {
+    $tag = calendarTag(
+        params: [],
+        context: ['id' => 'legacy-id']
+    );
+
+    expect($tag->icsDownloadUrl())->toContain('legacy-id');
+});

--- a/tests/Unit/OccurrenceDataTest.php
+++ b/tests/Unit/OccurrenceDataTest.php
@@ -2,7 +2,15 @@
 
 declare(strict_types=1);
 
+use Carbon\Carbon;
 use ElSchneider\StatamicCalendar\Occurrences\OccurrenceData;
+
+test('composeId formats as {entry_id}-{Y-m-d-His} and coerces int ids', function () {
+    $start = Carbon::parse('2026-03-06 15:00:00');
+
+    expect(OccurrenceData::composeId('abc-123', $start))->toBe('abc-123-2026-03-06-150000');
+    expect(OccurrenceData::composeId(42, $start))->toBe('42-2026-03-06-150000');
+});
 
 test('OccurrenceData can be created from array and serialized back', function () {
     $data = [


### PR DESCRIPTION
## Problem

`{{ calendar:ics_download_url :occurrence_id="id" }}` inside a `{{ calendar }}` loop is documented in the README but silently broken:

- `IcsController::download` matches on the composed `{entry_id}-{Y-m-d-His}`
- Loop items exposed `id` = entry id only (via `occurrenceDataToArray`) or the augmented entry id (via `occurrenceToArray`)
- So the generated URL never matches any cached occurrence → 404

## Fix

Expose the composed occurrence id as `occurrence_id` in loop items from both paths (cached `occurrenceDataToArray`, live `occurrenceToArray`). Matches the existing `{{ calendar:current_occurrence }}` context key.

`icsDownloadUrl` now falls back to `context.occurrence_id` before `context.id`, so `{{ calendar:ics_download_url }}` without params just works in any loop.

Non-breaking: `id` still resolves to entry id. Anyone who was using `:occurrence_id="id"` per README will now get the correct composed id by dropping the param.

README updated.