### PR TITLE
feat: expose excluded occurrences as first-class data

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ STATAMIC_CALENDAR_API_ENABLED=true
 | `sort`      | `string` | `asc` or `desc`                 | `asc`   |
 | `tags`      | `string` | Comma-separated tag slugs       | —       |
 | `organizer` | `string` | Organizer entry ID              | —       |
+| `include_excluded` | `bool` | Surface cancelled/rescheduled occurrences (`is_excluded`, `replacement_date`, `replaces_date`) | `false` |
 
 ### Response
 
@@ -216,7 +217,10 @@ STATAMIC_CALENDAR_API_ENABLED=true
       "is_all_day": false,
       "is_recurring": true,
       "recurrence_description": "every week on Friday",
-      "url": "/events/laracon-online?date=2026-03-06"
+      "url": "/events/laracon-online?date=2026-03-06",
+      "is_excluded": false,
+      "replacement_date": null,
+      "replaces_date": null
     }
   ]
 }

--- a/resources/examples/blueprints/collections/events/event.yaml
+++ b/resources/examples/blueprints/collections/events/event.yaml
@@ -188,7 +188,7 @@ tabs:
                   field:
                     type: grid
                     display: Exclusions
-                    instructions: 'Dates to exclude from the recurrence'
+                    instructions: 'Dates to exclude from the recurrence. Exclusions surface as occurrences with `is_excluded: true` when templates opt in via `include_excluded="true"`, so cancelled or rescheduled dates remain visible. Set `Moved to` to link an exclusion to the rescheduled date; any occurrence on that date exposes `replaces_date` pointing back to this exclusion.'
                     add_row: 'Add Exclusion'
                     mode: table
                     if:
@@ -200,7 +200,7 @@ tabs:
                           display: Date
                           time_enabled: false
                           required: true
-                          width: 66
+                          width: 33
                           validate:
                             - required
                       - handle: time
@@ -208,6 +208,13 @@ tabs:
                           type: text
                           display: Time
                           input_type: time
+                          width: 33
+                      - handle: replacement_date
+                        field:
+                          type: date
+                          display: 'Moved to'
+                          instructions: 'Optional — if this occurrence was rescheduled rather than cancelled, set the new date here.'
+                          time_enabled: false
                           width: 33
                 - handle: additions
                   field:

--- a/resources/views/statamic-calendar/index.antlers.html
+++ b/resources/views/statamic-calendar/index.antlers.html
@@ -142,22 +142,47 @@
         <div>
             <h1 class="text-3xl font-bold mb-8">Upcoming Events</h1>
 
+            {{#
+                `include_excluded="true"` surfaces cancelled/rescheduled occurrences
+                with `is_excluded`, `replacement_date`, and `replaces_date` so you can
+                render strike-through cancellations and "moved to …" links inline.
+                Omit the parameter to keep the default behaviour (excluded dates hidden).
+            #}}
             <div class="space-y-4">
-                {{ calendar from="now" limit="10" }}
-                    <a
-                        href="{{ url }}"
-                        class="block p-4 bg-white dark:bg-zinc-800 rounded shadow hover:shadow-md hover:bg-zinc-50 dark:hover:bg-zinc-700/50 transition-all"
-                    >
-                        <h2 class="text-lg font-semibold">{{ title }}</h2>
-                        <p class="text-sm text-zinc-500 dark:text-zinc-400">
-                            {{ start format="l, M j, Y" }}
-                            {{ if start_time }}at {{ start format="g:i A" }}{{ /if }}
-                            {{ if is_all_day }}(All day){{ /if }}
-                        </p>
-                        {{ if is_recurring }}
-                            <p class="text-xs text-zinc-400 dark:text-zinc-500 mt-1">↻ {{ recurrence_description }}</p>
-                        {{ /if }}
-                    </a>
+                {{ calendar from="now" limit="10" include_excluded="true" }}
+                    {{ if is_excluded }}
+                        <div class="block p-4 bg-white dark:bg-zinc-800 rounded shadow opacity-60">
+                            <h2 class="text-lg font-semibold line-through">{{ title }}</h2>
+                            <p class="text-sm text-zinc-500 dark:text-zinc-400">
+                                <span class="line-through">{{ start format="l, M j, Y" }}</span>
+                                {{ if replacement_date }}
+                                    <span class="ml-2 not-italic text-blue-600 dark:text-blue-400">
+                                        → moved to {{ replacement_date format="l, M j" }}
+                                    </span>
+                                {{ else }}
+                                    <span class="ml-2 text-red-600 dark:text-red-400">(cancelled)</span>
+                                {{ /if }}
+                            </p>
+                        </div>
+                    {{ else }}
+                        <a
+                            href="{{ url }}"
+                            class="block p-4 bg-white dark:bg-zinc-800 rounded shadow hover:shadow-md hover:bg-zinc-50 dark:hover:bg-zinc-700/50 transition-all"
+                        >
+                            <h2 class="text-lg font-semibold">{{ title }}</h2>
+                            <p class="text-sm text-zinc-500 dark:text-zinc-400">
+                                {{ start format="l, M j, Y" }}
+                                {{ if start_time }}at {{ start format="g:i A" }}{{ /if }}
+                                {{ if is_all_day }}(All day){{ /if }}
+                                {{ if replaces_date }}
+                                    <span class="ml-2 text-xs text-zinc-400">(rescheduled from {{ replaces_date format="M j" }})</span>
+                                {{ /if }}
+                            </p>
+                            {{ if is_recurring }}
+                                <p class="text-xs text-zinc-400 dark:text-zinc-500 mt-1">↻ {{ recurrence_description }}</p>
+                            {{ /if }}
+                        </a>
+                    {{ /if }}
                 {{ /calendar }}
             </div>
         </div>

--- a/resources/views/statamic-calendar/index.antlers.html
+++ b/resources/views/statamic-calendar/index.antlers.html
@@ -143,10 +143,9 @@
             <h1 class="text-3xl font-bold mb-8">Upcoming Events</h1>
 
             {{#
-                `include_excluded="true"` surfaces cancelled/rescheduled occurrences
-                with `is_excluded`, `replacement_date`, and `replaces_date` so you can
-                render strike-through cancellations and "moved to …" links inline.
-                Omit the parameter to keep the default behaviour (excluded dates hidden).
+                `include_excluded="true"` surfaces cancelled/rescheduled occurrences with `is_excluded`, `replacement_date`, and
+                `replaces_date` so you can render strike-through cancellations and "moved to …" links inline. Omit the parameter to keep
+                the default behaviour (excluded dates hidden).
             #}}
             <div class="space-y-4">
                 {{ calendar from="now" limit="10" include_excluded="true" }}
@@ -175,11 +174,15 @@
                                 {{ if start_time }}at {{ start format="g:i A" }}{{ /if }}
                                 {{ if is_all_day }}(All day){{ /if }}
                                 {{ if replaces_date }}
-                                    <span class="ml-2 text-xs text-zinc-400">(rescheduled from {{ replaces_date format="M j" }})</span>
+                                    <span class="ml-2 text-xs text-zinc-400">
+                                        (rescheduled from {{ replaces_date format="M j" }})
+                                    </span>
                                 {{ /if }}
                             </p>
                             {{ if is_recurring }}
-                                <p class="text-xs text-zinc-400 dark:text-zinc-500 mt-1">↻ {{ recurrence_description }}</p>
+                                <p class="text-xs text-zinc-400 dark:text-zinc-500 mt-1">
+                                    ↻ {{ recurrence_description }}
+                                </p>
                             {{ /if }}
                         </a>
                     {{ /if }}

--- a/src/Facades/Occurrences.php
+++ b/src/Facades/Occurrences.php
@@ -11,12 +11,12 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static Collection<int, OccurrenceData> all()
- * @method static Collection<int, OccurrenceData> on(Carbon $date)
- * @method static Collection<int, OccurrenceData> between(Carbon $from, Carbon $to)
- * @method static Collection<int, OccurrenceData> forEntry(string|int $entryId)
- * @method static Collection<int, OccurrenceData> forOrganizer(string|int|null $organizerId)
- * @method static Collection<int, OccurrenceData> upcoming(int $limit = 10)
+ * @method static Collection<int, OccurrenceData> all(bool $includeExcluded = false)
+ * @method static Collection<int, OccurrenceData> on(Carbon $date, bool $includeExcluded = false)
+ * @method static Collection<int, OccurrenceData> between(Carbon $from, Carbon $to, bool $includeExcluded = false)
+ * @method static Collection<int, OccurrenceData> forEntry(string|int $entryId, bool $includeExcluded = false)
+ * @method static Collection<int, OccurrenceData> forOrganizer(string|int|null $organizerId, bool $includeExcluded = false)
+ * @method static Collection<int, OccurrenceData> upcoming(int $limit = 10, bool $includeExcluded = false)
  * @method static void rebuild()
  * @method static void clear()
  * @method static bool isBuilt()

--- a/src/Http/Controllers/ApiOccurrenceController.php
+++ b/src/Http/Controllers/ApiOccurrenceController.php
@@ -21,8 +21,9 @@ class ApiOccurrenceController
         $sort = $request->query('sort', 'asc') === 'desc' ? 'desc' : 'asc';
         $tags = $request->query('tags');
         $organizer = $request->query('organizer');
+        $includeExcluded = $request->boolean('include_excluded');
 
-        $occurrences = Occurrences::all()
+        $occurrences = Occurrences::all($includeExcluded)
             ->filter(fn (OccurrenceData $o) => $o->start->gte($from))
             ->when($to, fn ($c) => $c->filter(fn (OccurrenceData $o) => $o->start->lte($to)));
 

--- a/src/Occurrences/Occurrence.php
+++ b/src/Occurrences/Occurrence.php
@@ -10,6 +10,16 @@ use Throwable;
 
 class Occurrence
 {
+    /**
+     * @param  bool  $isExcluded  The occurrence matches a row in the exclusions grid.
+     *                            Excluded occurrences carry no meaningful URL and are
+     *                            hidden from reads by default; templates/APIs must opt
+     *                            in via `include_excluded` to see them.
+     * @param  ?Carbon  $replacementDate  If this excluded occurrence was rescheduled,
+     *                                    the date it moved to. Null for simple cancellations.
+     * @param  ?Carbon  $replacesDate  If this occurrence is the replacement for a
+     *                                 rescheduled exclusion, the original date it replaces.
+     */
     public function __construct(
         public readonly Entry $entry,
         public readonly Carbon $start,
@@ -17,10 +27,19 @@ class Occurrence
         public readonly bool $isAllDay,
         public readonly bool $isRecurring,
         public readonly ?string $recurrenceDescription = null,
+        public readonly bool $isExcluded = false,
+        public readonly ?Carbon $replacementDate = null,
+        public readonly ?Carbon $replacesDate = null,
     ) {}
 
     public function url(?string $entryUrl = null): string
     {
+        // Excluded occurrences have no meaningful destination — they represent
+        // cancellations or rescheduled-away dates, not routable events.
+        if ($this->isExcluded) {
+            return '';
+        }
+
         $strategy = (string) $this->cfg('statamic-calendar.url.strategy', 'date_segments');
 
         if ($strategy === 'query_string') {

--- a/src/Occurrences/OccurrenceCache.php
+++ b/src/Occurrences/OccurrenceCache.php
@@ -16,9 +16,13 @@ use Statamic\Facades\Entry;
 class OccurrenceCache
 {
     /**
+     * Excluded occurrences are always stored in the cache so the dataset
+     * stays complete. Reads filter them out by default — pass
+     * $includeExcluded=true to surface cancellations and rescheduled dates.
+     *
      * @return Collection<int, OccurrenceData>
      */
-    public function all(): Collection
+    public function all(bool $includeExcluded = false): Collection
     {
         if (! $this->isBuilt()) {
             $this->rebuild();
@@ -26,15 +30,19 @@ class OccurrenceCache
 
         $cached = Cache::get($this->cacheKey(), []);
 
-        return collect($cached)->map(fn (array $data) => OccurrenceData::fromArray($data));
+        $occurrences = collect($cached)->map(fn (array $data) => OccurrenceData::fromArray($data));
+
+        return $includeExcluded
+            ? $occurrences
+            : $occurrences->reject(fn (OccurrenceData $o) => $o->isExcluded)->values();
     }
 
     /**
      * @return Collection<int, OccurrenceData>
      */
-    public function on(Carbon $date): Collection
+    public function on(Carbon $date, bool $includeExcluded = false): Collection
     {
-        return $this->all()->filter(
+        return $this->all($includeExcluded)->filter(
             fn (OccurrenceData $o) => $o->start->isSameDay($date)
         )->values();
     }
@@ -42,9 +50,9 @@ class OccurrenceCache
     /**
      * @return Collection<int, OccurrenceData>
      */
-    public function between(Carbon $from, Carbon $to): Collection
+    public function between(Carbon $from, Carbon $to, bool $includeExcluded = false): Collection
     {
-        return $this->all()->filter(
+        return $this->all($includeExcluded)->filter(
             fn (OccurrenceData $o) => $o->start->gte($from) && $o->start->lte($to)
         )->values();
     }
@@ -52,11 +60,11 @@ class OccurrenceCache
     /**
      * @return Collection<int, OccurrenceData>
      */
-    public function forEntry(string|int $entryId): Collection
+    public function forEntry(string|int $entryId, bool $includeExcluded = false): Collection
     {
         $entryId = (string) $entryId;
 
-        return $this->all()->filter(
+        return $this->all($includeExcluded)->filter(
             fn (OccurrenceData $o) => $o->entryId === $entryId
         )->values();
     }
@@ -64,11 +72,11 @@ class OccurrenceCache
     /**
      * @return Collection<int, OccurrenceData>
      */
-    public function forOrganizer(string|int|null $organizerId): Collection
+    public function forOrganizer(string|int|null $organizerId, bool $includeExcluded = false): Collection
     {
         $organizerId = $organizerId !== null ? (string) $organizerId : null;
 
-        return $this->all()->filter(
+        return $this->all($includeExcluded)->filter(
             fn (OccurrenceData $o) => $o->organizerId === $organizerId
         )->values();
     }
@@ -76,11 +84,11 @@ class OccurrenceCache
     /**
      * @return Collection<int, OccurrenceData>
      */
-    public function upcoming(int $limit = 10): Collection
+    public function upcoming(int $limit = 10, bool $includeExcluded = false): Collection
     {
         $now = Carbon::now();
 
-        return $this->all()
+        return $this->all($includeExcluded)
             ->filter(fn (OccurrenceData $o) => $o->start->gte($now))
             ->sortBy(fn (OccurrenceData $o) => $o->start)
             ->take($limit)
@@ -128,7 +136,9 @@ class OccurrenceCache
                 continue;
             }
 
-            $eventOccurrences = $resolver->resolve($entry, $eventFrom, $to);
+            // Always cache excluded occurrences — the store is the source of
+            // truth, and read-time filtering honors the caller's intent.
+            $eventOccurrences = $resolver->resolve($entry, $eventFrom, $to, includeExcluded: true);
 
             $entryId = (string) $entry->id();
             $organizerData = $this->extractOrganizerData($entry);
@@ -151,6 +161,9 @@ class OccurrenceCache
                     'is_recurring' => $occurrence->isRecurring,
                     'recurrence_description' => $occurrence->recurrenceDescription,
                     'url' => $occurrence->url(),
+                    'is_excluded' => $occurrence->isExcluded,
+                    'replacement_date' => $occurrence->replacementDate?->toIso8601String(),
+                    'replaces_date' => $occurrence->replacesDate?->toIso8601String(),
                 ];
 
                 $event = new OccurrenceBuilding($entry, $occurrence);

--- a/src/Occurrences/OccurrenceData.php
+++ b/src/Occurrences/OccurrenceData.php
@@ -32,6 +32,9 @@ readonly class OccurrenceData
         'is_recurring',
         'recurrence_description',
         'url',
+        'is_excluded',
+        'replacement_date',
+        'replaces_date',
     ];
 
     /**
@@ -40,6 +43,12 @@ readonly class OccurrenceData
      * @param  array<string, mixed>  $extra  Extra fields contributed by `OccurrenceBuilding`
      *                                       listeners at cache build time. Splatted onto `toArray()`
      *                                       so they surface in API and tag output.
+     * @param  bool  $isExcluded  Occurrence was cancelled or rescheduled away from this date.
+     *                            Hidden from reads by default — opt in via `include_excluded`.
+     * @param  ?Carbon  $replacementDate  For excluded occurrences: the date the event moved to.
+     *                                    Null when the occurrence was cancelled outright.
+     * @param  ?Carbon  $replacesDate  For non-excluded occurrences that replace a rescheduled one:
+     *                                 the original date this occurrence replaces.
      */
     public function __construct(
         public string $id,
@@ -59,6 +68,9 @@ readonly class OccurrenceData
         public ?string $recurrenceDescription,
         public string $url,
         public array $extra = [],
+        public bool $isExcluded = false,
+        public ?Carbon $replacementDate = null,
+        public ?Carbon $replacesDate = null,
     ) {}
 
     /**
@@ -92,6 +104,9 @@ readonly class OccurrenceData
             recurrenceDescription: $data['recurrence_description'] ?? null,
             url: $data['url'],
             extra: $extra,
+            isExcluded: (bool) ($data['is_excluded'] ?? false),
+            replacementDate: ! empty($data['replacement_date']) ? Carbon::parse($data['replacement_date']) : null,
+            replacesDate: ! empty($data['replaces_date']) ? Carbon::parse($data['replaces_date']) : null,
         );
     }
 
@@ -116,6 +131,9 @@ readonly class OccurrenceData
             'is_recurring' => $this->isRecurring,
             'recurrence_description' => $this->recurrenceDescription,
             'url' => $this->url,
+            'is_excluded' => $this->isExcluded,
+            'replacement_date' => $this->replacementDate?->toIso8601String(),
+            'replaces_date' => $this->replacesDate?->toIso8601String(),
         ];
     }
 

--- a/src/Occurrences/OccurrenceResolver.php
+++ b/src/Occurrences/OccurrenceResolver.php
@@ -14,7 +14,14 @@ use Statamic\Entries\Entry;
 
 class OccurrenceResolver
 {
-    public function resolve(Entry $entry, Carbon $from, ?Carbon $to = null, ?int $limit = null): Collection
+    /**
+     * Resolve occurrences for an entry within an optional window.
+     *
+     * Exclusions are emitted as occurrences carrying `isExcluded: true` when
+     * $includeExcluded is set; otherwise they are filtered out silently (the
+     * default, preserving backwards-compatible behavior).
+     */
+    public function resolve(Entry $entry, Carbon $from, ?Carbon $to = null, ?int $limit = null, bool $includeExcluded = false): Collection
     {
         $occurrences = collect();
 
@@ -23,7 +30,7 @@ class OccurrenceResolver
                 continue;
             }
 
-            $rowOccurrences = $this->resolveDateRow($entry, $dateRow, $from, $to, $limit);
+            $rowOccurrences = $this->resolveDateRow($entry, $dateRow, $from, $to, $limit, $includeExcluded);
             $occurrences = $occurrences->merge($rowOccurrences);
         }
 
@@ -55,7 +62,7 @@ class OccurrenceResolver
         );
     }
 
-    public function findOccurrenceOnDate(Entry $entry, Carbon $date): ?Occurrence
+    public function findOccurrenceOnDate(Entry $entry, Carbon $date, bool $includeExcluded = false): ?Occurrence
     {
         $tz = $this->timezone();
         $startOfDay = $date->copy()->setTimezone($tz)->startOfDay();
@@ -65,6 +72,7 @@ class OccurrenceResolver
             entry: $entry,
             from: $startOfDay,
             to: $endOfDay,
+            includeExcluded: $includeExcluded,
         );
 
         return $occurrences->first(function (Occurrence $o) use ($date, $tz) {
@@ -87,6 +95,7 @@ class OccurrenceResolver
                 Carbon::create(1, 1, 1, 0, 0, 0, $this->timezone()),
                 null,
                 null,
+                includeExcluded: false,
                 representativeAt: $at,
             ));
         }
@@ -102,7 +111,7 @@ class OccurrenceResolver
             ->first();
     }
 
-    private function resolveDateRow(Entry $entry, array $row, Carbon $from, ?Carbon $to, ?int $limit, ?Carbon $representativeAt = null): Collection
+    private function resolveDateRow(Entry $entry, array $row, Carbon $from, ?Carbon $to, ?int $limit, bool $includeExcluded = false, ?Carbon $representativeAt = null): Collection
     {
         $isRecurring = (bool) ($row['is_recurring'] ?? false);
 
@@ -110,10 +119,10 @@ class OccurrenceResolver
             return $this->resolveSingleDate($entry, $row, $from, $to);
         }
 
-        return $this->resolveRecurringDate($entry, $row, $from, $to, $limit, $representativeAt);
+        return $this->resolveRecurringDate($entry, $row, $from, $to, $limit, $includeExcluded, $representativeAt);
     }
 
-    private function resolveRecurringDate(Entry $entry, array $row, Carbon $from, ?Carbon $to, ?int $limit, ?Carbon $representativeAt = null): Collection
+    private function resolveRecurringDate(Entry $entry, array $row, Carbon $from, ?Carbon $to, ?int $limit, bool $includeExcluded = false, ?Carbon $representativeAt = null): Collection
     {
         if (! $to && ! $limit && ! $representativeAt) {
             $to = $from->copy()->addYear();
@@ -127,25 +136,18 @@ class OccurrenceResolver
 
         $tz = new DateTimeZone($this->timezone());
 
+        // No EXDATEs: excluded dates stay in the iteration so they can be
+        // emitted as first-class occurrences instead of silently vanishing.
         $rset = new RSet;
         $rset->addRRule($rruleParams);
 
-        foreach (($row['exclusions'] ?? []) as $exclusion) {
-            if (! is_array($exclusion) || empty($exclusion['date'])) {
-                continue;
-            }
+        $exclusions = $this->parseExclusions($row, $tz);
 
-            $day = $this->localDate($exclusion['date']);
-            if (! $day) {
-                continue;
-            }
-
-            $time = $this->localTime($exclusion['time'] ?? null)
-                ?? $this->localTime($row['start_time'] ?? null)
-                ?? '00:00';
-
-            $rset->addExDate(new DateTimeImmutable($day.' '.$time, $tz));
-        }
+        // Keyed by date only — the blueprint stores a bare replacement date,
+        // so linking back to the occurrence that replaces it is date-level.
+        $replacementsByDate = collect($exclusions)
+            ->filter(fn (array $e) => $e['replacement_date'] !== null)
+            ->keyBy(fn (array $e) => $e['replacement_date']->format('Y-m-d'));
 
         foreach (($row['additions'] ?? []) as $addition) {
             if (! is_array($addition) || empty($addition['date'])) {
@@ -168,6 +170,12 @@ class OccurrenceResolver
 
         foreach ($rset as $date) {
             $start = Carbon::instance($date);
+
+            $exclusion = $exclusions[$start->format('Y-m-d H:i:s')] ?? null;
+
+            if ($exclusion && ! $includeExcluded) {
+                continue;
+            }
 
             if ($start->lt($from)) {
                 continue;
@@ -192,6 +200,11 @@ class OccurrenceResolver
                 isAllDay: (bool) ($row['is_all_day'] ?? false),
                 isRecurring: true,
                 recurrenceDescription: $recurrenceDescription,
+                isExcluded: $exclusion !== null,
+                replacementDate: $exclusion['replacement_date'] ?? null,
+                replacesDate: $exclusion === null
+                    ? ($replacementsByDate[$start->format('Y-m-d')]['datetime'] ?? null)
+                    : null,
             );
 
             if ($representativeAt) {
@@ -210,6 +223,42 @@ class OccurrenceResolver
         }
 
         return $occurrences;
+    }
+
+    /**
+     * Exclusion rows keyed by their exact wall-clock datetime, matching how
+     * RSet dates are formatted during iteration.
+     *
+     * @return array<string, array{datetime: Carbon, replacement_date: ?Carbon}>
+     */
+    private function parseExclusions(array $row, DateTimeZone $tz): array
+    {
+        $parsed = [];
+
+        foreach (($row['exclusions'] ?? []) as $exclusion) {
+            if (! is_array($exclusion) || empty($exclusion['date'])) {
+                continue;
+            }
+
+            $day = $this->localDate($exclusion['date']);
+            if (! $day) {
+                continue;
+            }
+
+            $time = $this->localTime($exclusion['time'] ?? null)
+                ?? $this->localTime($row['start_time'] ?? null)
+                ?? '00:00';
+
+            $datetime = Carbon::parse($day.' '.$time, $tz);
+            $replacementDay = $this->localDate($exclusion['replacement_date'] ?? null);
+
+            $parsed[$datetime->format('Y-m-d H:i:s')] = [
+                'datetime' => $datetime,
+                'replacement_date' => $replacementDay ? Carbon::parse($replacementDay, $tz) : null,
+            ];
+        }
+
+        return $parsed;
     }
 
     private function getAdditionEndTime(array $additions, Carbon $date): ?string

--- a/src/Tags/Calendar.php
+++ b/src/Tags/Calendar.php
@@ -38,14 +38,15 @@ class Calendar extends Tags
         $sort = (string) $this->params->get('sort', 'asc');
         $paginate = $this->params->int('paginate');
         $pageName = (string) $this->params->get('page_name', 'page');
+        $includeExcluded = $this->params->bool('include_excluded', false);
 
         $tags = $this->params->get('tags');
 
         if ($collection === config('statamic-calendar.collection', 'events')) {
-            return $this->indexFromCache($from, $to, $limit, $tags, $sort, $paginate, $pageName);
+            return $this->indexFromCache($from, $to, $limit, $tags, $sort, $paginate, $pageName, $includeExcluded);
         }
 
-        return $this->indexFromResolver($collection, $from, $to, $limit, $tags, $sort, $paginate, $pageName);
+        return $this->indexFromResolver($collection, $from, $to, $limit, $tags, $sort, $paginate, $pageName, $includeExcluded);
     }
 
     /**
@@ -158,6 +159,8 @@ class Calendar extends Tags
         $collection = (string) $this->params->get('collection', config('statamic-calendar.collection', 'events'));
         $tags = $this->params->get('tags');
 
+        $includeExcluded = $this->params->bool('include_excluded', false);
+
         $monthValue = request()->query($param);
         $current = ($monthValue && is_string($monthValue) && preg_match('/^\d{4}-\d{2}$/', $monthValue))
             ? Carbon::createFromFormat('Y-m', $monthValue)->startOfMonth()
@@ -166,8 +169,8 @@ class Calendar extends Tags
         [$gridStart, $gridEnd] = $this->monthGridBoundaries($current, $weekStartsOn, $fixedRows);
 
         $occurrences = ($collection === config('statamic-calendar.collection', 'events'))
-            ? $this->indexFromCache($gridStart, $gridEnd, null, $tags)
-            : $this->indexFromResolver($collection, $gridStart, $gridEnd, null, $tags);
+            ? $this->indexFromCache($gridStart, $gridEnd, null, $tags, includeExcluded: $includeExcluded)
+            : $this->indexFromResolver($collection, $gridStart, $gridEnd, null, $tags, includeExcluded: $includeExcluded);
 
         $grouped = collect($occurrences)->groupBy(
             fn (array $o) => Carbon::parse($o['start'])->format('Y-m-d')
@@ -210,8 +213,9 @@ class Calendar extends Tags
 
         $to = $this->params->has('to') ? Carbon::parse((string) $this->params->get('to')) : null;
         $limit = $this->params->int('limit', 5);
+        $includeExcluded = $this->params->bool('include_excluded', false);
 
-        $occurrences = $this->resolver->resolve($entry, $from, $to, $limit);
+        $occurrences = $this->resolver->resolve($entry, $from, $to, $limit, $includeExcluded);
 
         if ($contextStart && ! $this->params->bool('include_current', false)) {
             $occurrences = $occurrences->reject(fn (Occurrence $o) => $o->start->equalTo($contextStart));
@@ -325,9 +329,9 @@ class Calendar extends Tags
         return $labels;
     }
 
-    private function indexFromCache(Carbon $from, ?Carbon $to, ?int $limit, $tags, string $sort = 'asc', int $paginate = 0, string $pageName = 'page'): mixed
+    private function indexFromCache(Carbon $from, ?Carbon $to, ?int $limit, $tags, string $sort = 'asc', int $paginate = 0, string $pageName = 'page', bool $includeExcluded = false): mixed
     {
-        $occurrences = Occurrences::all()
+        $occurrences = Occurrences::all($includeExcluded)
             ->filter(fn (OccurrenceData $o) => $o->start->gte($from))
             ->when($to, fn ($c) => $c->filter(fn (OccurrenceData $o) => $o->start->lte($to)));
 
@@ -395,7 +399,7 @@ class Calendar extends Tags
      * pass an explicit `to` to shrink the working set, or use the cached default
      * collection.
      */
-    private function indexFromResolver(string $collection, Carbon $from, ?Carbon $to, ?int $limit, $tags, string $sort = 'asc', int $paginate = 0, string $pageName = 'page'): mixed
+    private function indexFromResolver(string $collection, Carbon $from, ?Carbon $to, ?int $limit, $tags, string $sort = 'asc', int $paginate = 0, string $pageName = 'page', bool $includeExcluded = false): mixed
     {
         $query = Entry::query()->where('collection', $collection);
 
@@ -422,7 +426,7 @@ class Calendar extends Tags
                 continue;
             }
 
-            $occurrences = $this->resolver->resolve($entry, $from, $to, $resolverLimit);
+            $occurrences = $this->resolver->resolve($entry, $from, $to, $resolverLimit, $includeExcluded);
             $allOccurrences = $allOccurrences->merge($occurrences);
         }
 
@@ -472,6 +476,9 @@ class Calendar extends Tags
             'is_recurring' => $occurrence->isRecurring,
             'recurrence_description' => $occurrence->recurrenceDescription,
             'url' => $occurrence->url(),
+            'is_excluded' => $occurrence->isExcluded,
+            'replacement_date' => $occurrence->replacementDate,
+            'replaces_date' => $occurrence->replacesDate,
         ]);
     }
 
@@ -491,6 +498,9 @@ class Calendar extends Tags
             'is_recurring' => $occurrence->isRecurring,
             'recurrence_description' => $occurrence->recurrenceDescription,
             'url' => $occurrence->url,
+            'is_excluded' => $occurrence->isExcluded,
+            'replacement_date' => $occurrence->replacementDate,
+            'replaces_date' => $occurrence->replacesDate,
         ];
     }
 }

--- a/tests/Feature/ApiOccurrenceTest.php
+++ b/tests/Feature/ApiOccurrenceTest.php
@@ -51,8 +51,22 @@ beforeEach(function () {
         ]),
     ]);
 
+    $excluded = makeApiOccurrence([
+        'id' => 'eee-2026-03-15-100000',
+        'entry_id' => 'eee',
+        'title' => 'Cancelled Yoga',
+        'slug' => 'cancelled-yoga',
+        'start' => '2026-03-15T10:00:00+00:00',
+        'end' => '2026-03-15T11:00:00+00:00',
+        'is_excluded' => true,
+        'replacement_date' => '2026-03-22T00:00:00+00:00',
+    ]);
+
     $mock = Mockery::mock(OccurrenceCache::class);
-    $mock->shouldReceive('all')->andReturn($this->occurrences);
+    // Mirror the cache contract: default (false) strips excluded, true keeps them.
+    // Fresh collections so the mocked returns can't alias each other.
+    $mock->shouldReceive('all')->with(false)->andReturnUsing(fn () => $this->occurrences->values());
+    $mock->shouldReceive('all')->with(true)->andReturnUsing(fn () => $this->occurrences->concat([$excluded])->values());
     $this->app->instance(OccurrenceCache::class, $mock);
 });
 
@@ -77,6 +91,9 @@ function makeApiOccurrence(array $overrides = []): OccurrenceData
         'is_recurring' => false,
         'recurrence_description' => null,
         'url' => '/events/test-event',
+        'is_excluded' => false,
+        'replacement_date' => null,
+        'replaces_date' => null,
     ], $overrides));
 }
 
@@ -249,4 +266,21 @@ test('max_per_page misconfigured to 0 does not error and clamps to 1', function 
     $this->getJson('/api/calendar/occurrences?from=2026-02-01&page=1&per_page=15')
         ->assertOk()
         ->assertJsonPath('per_page', 1);
+});
+
+test('excludes cancelled occurrences by default', function () {
+    $this->getJson('/api/calendar/occurrences')
+        ->assertOk()
+        ->assertJsonMissing(['title' => 'Cancelled Yoga']);
+});
+
+test('include_excluded=1 surfaces cancelled occurrences with metadata', function () {
+    $response = $this->getJson('/api/calendar/occurrences?include_excluded=1')->assertOk();
+
+    $titles = collect($response->json('data'))->pluck('title');
+    expect($titles)->toContain('Cancelled Yoga');
+
+    $cancelled = collect($response->json('data'))->firstWhere('title', 'Cancelled Yoga');
+    expect($cancelled['is_excluded'])->toBeTrue();
+    expect($cancelled['replacement_date'])->toContain('2026-03-22');
 });

--- a/tests/Feature/CalendarTagTest.php
+++ b/tests/Feature/CalendarTagTest.php
@@ -11,12 +11,28 @@ use Statamic\Contracts\View\Antlers\Parser;
 beforeEach(function () {
     Carbon::setTestNow('2026-02-01 00:00:00');
 
-    $this->tagOccurrences = collect([
-        calendarTagOccurrence(),
+    $visible = calendarTagOccurrence();
+
+    $excluded = calendarTagOccurrence([
+        'id' => 'aaa-2026-02-12-100000',
+        'start' => '2026-02-12T10:00:00+00:00',
+        'end' => '2026-02-12T11:00:00+00:00',
+        'is_recurring' => true,
+        'recurrence_description' => 'weekly',
+        'url' => '',
+        'is_excluded' => true,
+        'replacement_date' => '2026-02-19T00:00:00+00:00',
     ]);
 
+    $this->tagOccurrences = collect([$visible]);
+
     $mock = Mockery::mock(OccurrenceCache::class);
-    $mock->shouldReceive('all')->andReturn($this->tagOccurrences);
+    // The tag forwards $includeExcluded through to the cache — mirror that
+    // boundary so tests can verify the param is actually propagated. Build
+    // fresh collections each call so the mocked returns can't alias.
+    $mock->shouldReceive('all')->with(false)->andReturnUsing(fn () => collect([$visible]));
+    $mock->shouldReceive('all')->with(true)->andReturnUsing(fn () => collect([$visible, $excluded]));
+    $mock->shouldReceive('all')->withNoArgs()->andReturnUsing(fn () => collect([$visible]));
     $this->app->instance(OccurrenceCache::class, $mock);
 });
 
@@ -102,4 +118,22 @@ test('ics_download_url falls back to context id when occurrence_id absent', func
     );
 
     expect($tag->icsDownloadUrl())->toContain('legacy-id');
+});
+
+test('index hides excluded occurrences by default', function () {
+    $result = calendarTag(['from' => '2026-02-01'])->index();
+
+    expect($result)->toHaveCount(1);
+    expect(collect($result)->first()['is_excluded'])->toBeFalse();
+});
+
+test('include_excluded surfaces excluded occurrences with metadata', function () {
+    $result = calendarTag(['from' => '2026-02-01', 'include_excluded' => true])->index();
+
+    expect($result)->toHaveCount(2);
+
+    $excluded = collect($result)->firstWhere('is_excluded', true);
+    expect($excluded)->not->toBeNull();
+    expect($excluded['replacement_date']?->format('Y-m-d'))->toBe('2026-02-19');
+    expect($excluded['url'])->toBe('');
 });

--- a/tests/Feature/OccurrenceBuildingEventTest.php
+++ b/tests/Feature/OccurrenceBuildingEventTest.php
@@ -40,7 +40,7 @@ test('rebuild skips unpublished entries', function () {
     $resolver = Mockery::mock(OccurrenceResolver::class);
     $resolver->shouldReceive('resolve')
         ->once()
-        ->with($publishedEntry, Mockery::type(Carbon::class), Mockery::type(Carbon::class))
+        ->with($publishedEntry, Mockery::type(Carbon::class), Mockery::type(Carbon::class), null, true)
         ->andReturn(collect([
             new Occurrence($publishedEntry, Carbon::parse('2026-03-10 10:00'), null, false, false),
         ]));

--- a/tests/Feature/OccurrenceResolverTest.php
+++ b/tests/Feature/OccurrenceResolverTest.php
@@ -169,3 +169,117 @@ test('a malformed start_time falls back to midnight instead of crashing the rebu
     expect($occurrences)->toHaveCount(2);
     expect($occurrences->first()->start->format('Y-m-d H:i'))->toBe('2025-06-01 00:00');
 });
+
+/**
+ * @param  list<array<string, mixed>>  $dateRows
+ */
+function resolveFor(array $dateRows, Carbon $from, ?Carbon $to = null, bool $includeExcluded = false): Illuminate\Support\Collection
+{
+    return (new OccurrenceResolver)->resolve(entryWithDates($dateRows), $from, $to, null, $includeExcluded);
+}
+
+/**
+ * Weekly-Monday recurring row starting 2026-03-02, 5 occurrences, with an
+ * exclusion on 2026-03-16 moved to 2026-03-20 (Friday), plus that Friday as
+ * an addition so the replacement actually materializes as an occurrence.
+ */
+function sampleRescheduledRow(array $overrides = []): array
+{
+    // Shallow replace so overriding `exclusions`/`additions` fully replaces the
+    // sample array instead of merging element-by-element (which would leak
+    // replacement_date from the defaults into a plain cancellation scenario).
+    return array_replace([
+        'is_recurring' => true,
+        'start_date' => '2026-03-02',
+        'start_time' => '10:00',
+        'end_time' => '11:00',
+        'frequency' => 'WEEKLY',
+        'interval' => 1,
+        'weekdays' => ['MO'],
+        'recurrence_end' => 'count',
+        'count' => 5,
+        'exclusions' => [
+            ['date' => '2026-03-16', 'time' => '10:00', 'replacement_date' => '2026-03-20'],
+        ],
+        'additions' => [
+            ['date' => '2026-03-20', 'start_time' => '10:00', 'end_time' => '11:00'],
+        ],
+    ], $overrides);
+}
+
+afterEach(fn () => Mockery::close());
+
+test('excluded occurrences are hidden by default', function () {
+    $occurrences = resolveFor([sampleRescheduledRow()], Carbon::parse('2026-03-01'));
+
+    // RRULE COUNT=5 produces 5 Mondays; one is excluded; addition adds one.
+    // Default (includeExcluded=false) → 5 visible.
+    expect($occurrences)->toHaveCount(5);
+    expect($occurrences->pluck('start')->map(fn ($d) => $d->format('Y-m-d'))->all())
+        ->toBe(['2026-03-02', '2026-03-09', '2026-03-20', '2026-03-23', '2026-03-30']);
+    expect($occurrences->every(fn (Occurrence $o) => ! $o->isExcluded))->toBeTrue();
+});
+
+test('include_excluded surfaces the excluded date with is_excluded=true', function () {
+    $occurrences = resolveFor([sampleRescheduledRow()], Carbon::parse('2026-03-01'), includeExcluded: true);
+
+    expect($occurrences)->toHaveCount(6);
+
+    $excluded = $occurrences->first(fn (Occurrence $o) => $o->isExcluded);
+    expect($excluded)->not->toBeNull();
+    expect($excluded->start->format('Y-m-d'))->toBe('2026-03-16');
+    expect($excluded->url())->toBe(''); // excluded occurrences have no destination
+});
+
+test('excluded occurrences expose replacement_date pointing to the new date', function () {
+    $occurrences = resolveFor([sampleRescheduledRow()], Carbon::parse('2026-03-01'), includeExcluded: true);
+
+    $excluded = $occurrences->first(fn (Occurrence $o) => $o->isExcluded);
+    expect($excluded->replacementDate?->format('Y-m-d'))->toBe('2026-03-20');
+});
+
+test('replacement occurrences expose replaces_date pointing to the original', function () {
+    $occurrences = resolveFor([sampleRescheduledRow()], Carbon::parse('2026-03-01'));
+
+    $replacement = $occurrences->first(fn (Occurrence $o) => $o->start->format('Y-m-d') === '2026-03-20');
+    expect($replacement)->not->toBeNull();
+    expect($replacement->replacesDate?->format('Y-m-d'))->toBe('2026-03-16');
+});
+
+test('plain cancellation (no replacement_date) still marks is_excluded', function () {
+    $row = sampleRescheduledRow([
+        'exclusions' => [
+            ['date' => '2026-03-16', 'time' => '10:00'],
+        ],
+        'additions' => [],
+    ]);
+
+    $occurrences = resolveFor([$row], Carbon::parse('2026-03-01'), includeExcluded: true);
+
+    $excluded = $occurrences->first(fn (Occurrence $o) => $o->isExcluded);
+    expect($excluded)->not->toBeNull();
+    expect($excluded->replacementDate)->toBeNull();
+});
+
+test('exclusion without a time inherits the row start_time', function () {
+    $row = sampleRescheduledRow([
+        'exclusions' => [
+            ['date' => '2026-03-16'], // no time → falls back to 10:00
+        ],
+        'additions' => [],
+    ]);
+
+    $occurrences = resolveFor([$row], Carbon::parse('2026-03-01'), includeExcluded: true);
+
+    $excluded = $occurrences->first(fn (Occurrence $o) => $o->isExcluded);
+    expect($excluded)->not->toBeNull();
+});
+
+test('occurrences outside the window are still filtered when excluded', function () {
+    // Exclusion is before `from` — should not appear even with include_excluded.
+    $row = sampleRescheduledRow();
+    $occurrences = resolveFor([$row], Carbon::parse('2026-03-17'), includeExcluded: true);
+
+    expect($occurrences->every(fn (Occurrence $o) => $o->start->gte(Carbon::parse('2026-03-17'))))->toBeTrue();
+    expect($occurrences->contains(fn (Occurrence $o) => $o->start->format('Y-m-d') === '2026-03-16'))->toBeFalse();
+});

--- a/tests/Feature/OccurrenceResolverTest.php
+++ b/tests/Feature/OccurrenceResolverTest.php
@@ -283,3 +283,31 @@ test('occurrences outside the window are still filtered when excluded', function
     expect($occurrences->every(fn (Occurrence $o) => $o->start->gte(Carbon::parse('2026-03-17'))))->toBeTrue();
     expect($occurrences->contains(fn (Occurrence $o) => $o->start->format('Y-m-d') === '2026-03-16'))->toBeFalse();
 });
+
+test('limit ignores excluded occurrences when they are hidden', function () {
+    // Mondays 03-02, 03-09, 03-16 (excluded), 03-23, 03-30 + addition 03-20.
+    $occurrences = (new OccurrenceResolver)->resolve(
+        entryWithDates([sampleRescheduledRow()]),
+        Carbon::parse('2026-03-01'),
+        null,
+        3,
+    );
+
+    expect($occurrences->pluck('start')->map(fn ($d) => $d->format('Y-m-d'))->all())
+        ->toBe(['2026-03-02', '2026-03-09', '2026-03-20']);
+});
+
+test('limit counts excluded occurrences when the caller opts in', function () {
+    $occurrences = (new OccurrenceResolver)->resolve(
+        entryWithDates([sampleRescheduledRow()]),
+        Carbon::parse('2026-03-01'),
+        null,
+        3,
+        includeExcluded: true,
+    );
+
+    // The excluded 03-16 consumes a slot — `limit` means "N items", not
+    // "N visible items", otherwise the result size is unbounded.
+    expect($occurrences->pluck('start')->map(fn ($d) => $d->format('Y-m-d'))->all())
+        ->toBe(['2026-03-02', '2026-03-09', '2026-03-16']);
+});

--- a/tests/Unit/OccurrenceDataTest.php
+++ b/tests/Unit/OccurrenceDataTest.php
@@ -81,6 +81,65 @@ function baseOccurrenceArray(): array
     ];
 }
 
+test('OccurrenceData round-trips excluded + replacement metadata', function () {
+    $data = [
+        'id' => 'abc-2026-03-16-100000',
+        'entry_id' => 'abc',
+        'title' => 'Cancelled Event',
+        'slug' => 'cancelled-event',
+        'teaser' => null,
+        'organizer_id' => null,
+        'organizer_slug' => null,
+        'organizer_title' => null,
+        'organizer_url' => null,
+        'tags' => [],
+        'start' => '2026-03-16T10:00:00+00:00',
+        'end' => '2026-03-16T11:00:00+00:00',
+        'is_all_day' => false,
+        'is_recurring' => true,
+        'recurrence_description' => 'weekly on Monday',
+        'url' => '',
+        'is_excluded' => true,
+        'replacement_date' => '2026-03-20T00:00:00+00:00',
+        'replaces_date' => null,
+    ];
+
+    $occurrence = OccurrenceData::fromArray($data);
+
+    expect($occurrence->isExcluded)->toBeTrue();
+    expect($occurrence->replacementDate?->format('Y-m-d'))->toBe('2026-03-20');
+    expect($occurrence->replacesDate)->toBeNull();
+
+    $roundTripped = OccurrenceData::fromArray($occurrence->toArray());
+    expect($roundTripped->isExcluded)->toBeTrue();
+    expect($roundTripped->replacementDate?->format('Y-m-d'))->toBe('2026-03-20');
+});
+
+test('OccurrenceData defaults excluded flags when legacy array has no keys', function () {
+    $occurrence = OccurrenceData::fromArray([
+        'id' => 'legacy',
+        'entry_id' => 'legacy',
+        'title' => 'Legacy',
+        'slug' => 'legacy',
+        'teaser' => null,
+        'organizer_id' => null,
+        'organizer_slug' => null,
+        'organizer_title' => null,
+        'organizer_url' => null,
+        'tags' => [],
+        'start' => '2026-03-06T15:00:00+00:00',
+        'end' => null,
+        'is_all_day' => false,
+        'is_recurring' => false,
+        'recurrence_description' => null,
+        'url' => '/events/legacy',
+    ]);
+
+    expect($occurrence->isExcluded)->toBeFalse();
+    expect($occurrence->replacementDate)->toBeNull();
+    expect($occurrence->replacesDate)->toBeNull();
+});
+
 test('OccurrenceData normalizes numeric ids to strings', function () {
     $occurrence = OccurrenceData::fromArray([
         'id' => '1-2026-03-06-150000',


### PR DESCRIPTION
Closes #1.

## Problem

Exclusions on recurring dates were fed into `RSet::addExDate()`, which silently drops them. Cancelled or rescheduled occurrences vanished from templates, cache, API, and ICS — leaving no structural way to render "this date was cancelled" or "moved to …" links.

## Solution

Excluded dates become first-class occurrences carrying `is_excluded`, `replacement_date`, and `replaces_date`. Hidden by default (backwards compatible); opt in via `include_excluded`.

### Resolver strategy shift

Before: `RRule + addExDate()` → excluded dates vanish.
After: `RRule + RDATEs (additions)` → iterate every candidate date, tag matches against exclusions. One pass, no double resolution.

Bidirectional linking is automatic: when an exclusion's `replacement_date` matches another occurrence's date (RRule-generated or RDATE addition), that occurrence carries `replaces_date` pointing back to the original.

### Cache

Always stores excluded (complete dataset). Every read method (`all`, `on`, `between`, `forEntry`, `forOrganizer`, `upcoming`) gains `bool $includeExcluded = false`. Default filters excluded at read time.

### Surface

- `{{ calendar include_excluded="true" }}` / `{{ calendar:month include_excluded="true" }}` / `{{ calendar:next_occurrences include_excluded="true" }}`
- `GET /api/calendar/occurrences?include_excluded=1`
- Blueprint: `replacement_date` field on the exclusions grid
- ICS & `OccurrenceController::show()` keep default behavior (don't emit / 404 on excluded)
- Excluded occurrences' `url()` returns `''` — no routable destination

## Template pattern

Demonstrated in the example `index.antlers.html`:

```antlers
{{ calendar from="now" include_excluded="true" }}
  {{ if is_excluded }}
    <s>{{ title }} — {{ start format="M j" }}</s>
    {{ if replacement_date }}→ moved to {{ replacement_date format="M j" }}{{ /if }}
  {{ else }}
    <a href="{{ url }}">{{ title }}</a>
    {{ if replaces_date }}(rescheduled from {{ replaces_date format="M j" }}){{ /if }}
  {{ /if }}
{{ /calendar }}
```

## Tests

42 passing (was 29). New coverage:

- Resolver: default hides excluded; `include_excluded` surfaces them; `replacement_date` + `replaces_date` bidirectional linking; plain cancellation vs reschedule; time fallback; window filtering applies to excluded too
- `OccurrenceData`: round-trips new metadata; legacy arrays default safely
- Calendar tag: `include_excluded` parameter propagates through cache
- API: `include_excluded` query param surfaces cancelled occurrences

## Backwards compatibility

- `OccurrenceData::fromArray` defaults the three new fields from missing keys → cached entries from older builds still deserialize.
- All `$includeExcluded` parameters default to `false`, preserving existing behavior.
- ICS, URL resolution, and the occurrence detail route behave identically for non-excluded occurrences.
