### PR TITLE
feat: customizable API response via OccurrenceTransformer

### DIFF
--- a/config/statamic-calendar.php
+++ b/config/statamic-calendar.php
@@ -124,6 +124,18 @@ return [
         'enabled' => env('STATAMIC_CALENDAR_API_ENABLED', false),
         'route' => env('STATAMIC_CALENDAR_API_ROUTE', 'api/calendar/occurrences'),
         'middleware' => env('STATAMIC_CALENDAR_API_MIDDLEWARE', 'api'),
+
+        /*
+        | FQCN of a class implementing OccurrenceTransformer.
+        | When null the default transformer is used (returns OccurrenceData::toArray()).
+        */
+        'transformer' => null,
+
+        /*
+        | FQCN of a controller class with an index() method.
+        | When null the built-in ApiOccurrenceController is used.
+        */
+        'controller' => null,
     ],
 
     /*

--- a/src/Api/DefaultOccurrenceTransformer.php
+++ b/src/Api/DefaultOccurrenceTransformer.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ElSchneider\StatamicCalendar\Api;
+
+use ElSchneider\StatamicCalendar\Contracts\OccurrenceTransformer;
+use ElSchneider\StatamicCalendar\Occurrences\OccurrenceData;
+use Statamic\Entries\Entry;
+
+class DefaultOccurrenceTransformer implements OccurrenceTransformer
+{
+    public function transform(OccurrenceData $occurrence, ?Entry $entry): array
+    {
+        return $occurrence->toArray();
+    }
+}

--- a/src/Contracts/OccurrenceTransformer.php
+++ b/src/Contracts/OccurrenceTransformer.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ElSchneider\StatamicCalendar\Contracts;
+
+use ElSchneider\StatamicCalendar\Occurrences\OccurrenceData;
+use Statamic\Entries\Entry;
+
+interface OccurrenceTransformer
+{
+    /** @return array<string, mixed> */
+    public function transform(OccurrenceData $occurrence, ?Entry $entry): array;
+}

--- a/src/Http/Controllers/ApiOccurrenceController.php
+++ b/src/Http/Controllers/ApiOccurrenceController.php
@@ -5,21 +5,30 @@ declare(strict_types=1);
 namespace ElSchneider\StatamicCalendar\Http\Controllers;
 
 use Carbon\Carbon;
+use ElSchneider\StatamicCalendar\Contracts\OccurrenceTransformer;
 use ElSchneider\StatamicCalendar\Facades\Occurrences;
 use ElSchneider\StatamicCalendar\Occurrences\OccurrenceData;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Statamic\Entries\Entry;
+use Statamic\Facades\Entry as EntryFacade;
 
 class ApiOccurrenceController
 {
+    public function __construct(
+        private readonly OccurrenceTransformer $transformer,
+    ) {}
+
     public function index(Request $request): JsonResponse
     {
         $from = $request->has('from') ? Carbon::parse($request->query('from')) : Carbon::now();
         $to = $request->has('to') ? Carbon::parse($request->query('to')) : null;
-        $limit = $request->integer('limit') ?: null;
         $sort = $request->query('sort', 'asc') === 'desc' ? 'desc' : 'asc';
         $tags = $request->query('tags');
         $organizer = $request->query('organizer');
+        $page = max(1, $request->integer('page', 1));
+        $perPage = min(100, max(1, $request->integer('per_page', 20)));
 
         $occurrences = Occurrences::all()
             ->filter(fn (OccurrenceData $o) => $o->start->gte($from))
@@ -38,12 +47,39 @@ class ApiOccurrenceController
             ? $occurrences->sortByDesc(fn (OccurrenceData $o) => $o->start)
             : $occurrences->sortBy(fn (OccurrenceData $o) => $o->start);
 
-        if ($limit) {
-            $occurrences = $occurrences->take($limit);
-        }
+        $total = $occurrences->count();
+        $lastPage = max(1, (int) ceil($total / $perPage));
+        $paged = $occurrences->slice(($page - 1) * $perPage, $perPage)->values();
+
+        $entries = $this->getEntries($paged);
 
         return new JsonResponse([
-            'data' => $occurrences->map(fn (OccurrenceData $o) => $o->toArray())->values()->all(),
+            'data' => $paged
+                ->map(fn (OccurrenceData $o) => $this->transformer->transform(
+                    $o,
+                    $entries[$o->entryId] ?? null,
+                ))
+                ->values()
+                ->all(),
+            'meta' => [
+                'current_page' => $page,
+                'per_page' => $perPage,
+                'total' => $total,
+                'last_page' => $lastPage,
+            ],
         ]);
+    }
+
+    /**
+     * @return Collection<string, Entry>
+     */
+    private function getEntries(Collection $occurrences): Collection
+    {
+        $entryIds = $occurrences->pluck('entryId')->unique()->values()->all();
+
+        return EntryFacade::query()
+            ->whereIn('id', $entryIds)
+            ->get()
+            ->keyBy(fn (Entry $e) => (string) $e->id());
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -86,7 +86,7 @@ class ServiceProvider extends AddonServiceProvider
         $route = config('statamic-calendar.api.route', 'api/calendar/occurrences');
         $middleware = config('statamic-calendar.api.middleware', 'api');
 
-        $controller = config('statamic-calendar.api.controller', ApiOccurrenceController::class);
+        $controller = config('statamic-calendar.api.controller') ?: ApiOccurrenceController::class;
 
         Route::middleware($middleware)
             ->get($route, [$controller, 'index'])

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace ElSchneider\StatamicCalendar;
 
+use ElSchneider\StatamicCalendar\Api\DefaultOccurrenceTransformer;
 use ElSchneider\StatamicCalendar\Console\Commands\RebuildOccurrenceCacheCommand;
+use ElSchneider\StatamicCalendar\Contracts\OccurrenceTransformer;
 use ElSchneider\StatamicCalendar\Http\Controllers\ApiOccurrenceController;
 use ElSchneider\StatamicCalendar\Http\Controllers\IcsController;
 use ElSchneider\StatamicCalendar\Listeners\RebuildOccurrenceCacheOnEntryChange;
@@ -36,6 +38,12 @@ class ServiceProvider extends AddonServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/statamic-calendar.php', 'statamic-calendar');
 
         $this->app->singleton(OccurrenceCache::class);
+
+        $this->app->singleton(OccurrenceTransformer::class, function () {
+            $class = config('statamic-calendar.api.transformer');
+
+            return $class ? app($class) : new DefaultOccurrenceTransformer();
+        });
     }
 
     public function bootAddon()
@@ -78,8 +86,10 @@ class ServiceProvider extends AddonServiceProvider
         $route = config('statamic-calendar.api.route', 'api/calendar/occurrences');
         $middleware = config('statamic-calendar.api.middleware', 'api');
 
+        $controller = config('statamic-calendar.api.controller', ApiOccurrenceController::class);
+
         Route::middleware($middleware)
-            ->get($route, [ApiOccurrenceController::class, 'index'])
+            ->get($route, [$controller, 'index'])
             ->name('statamic-calendar.api.occurrences');
     }
 


### PR DESCRIPTION
- Add OccurrenceTransformer interface (src/Contracts)
- Add DefaultOccurrenceTransformer that preserves existing behaviour
- Inject transformer into ApiOccurrenceController, batch-load entries
- Replace limit param with page/per_page pagination
- Add api.transformer and api.controller config keys
- Bind transformer singleton in ServiceProvider
- Allow swapping the API controller via config

issue: https://github.com/el-schneider/statamic-calendar/issues/12