### PR TITLE
feat: add occurrence building extras event

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Recurring events and cached occurrences for Statamic. Works with Statamic 5 and 
 - Month calendar view — server-rendered, navigable via query params, no JS required
 - JSON REST API for JS-based calendar components (opt-in)
 - iCalendar (.ics) feed for calendar app subscriptions + per-event "Add to calendar" downloads
+- Cache-build event for adding custom occurrence fields to tag/API output
 - Two URL strategies: query string (default, Statamic-native) or date segments
 - Example templates for index (list, archive, calendar grid) and show pages
 
@@ -207,6 +208,10 @@ fetch('/api/calendar/occurrences?tags=music,art&organizer=org-123')
 ### CORS
 
 The API uses Laravel's `api` middleware group, so cross-origin requests are handled by your app's `config/cors.php`. Laravel's default config already allows `api/*` paths from all origins — adjust as needed.
+
+## Custom Occurrence Fields
+
+Need images, categories, or occurrence-specific flags in API/tag output? Listen to `ElSchneider\StatamicCalendar\Events\OccurrenceBuilding`. It runs once per materialized occurrence during cache rebuild, with access to both the source entry and resolved occurrence. See `config/statamic-calendar.php` and the event class docblock for the full recipe.
 
 ## Setting Up Templates
 

--- a/config/statamic-calendar.php
+++ b/config/statamic-calendar.php
@@ -118,6 +118,12 @@ return [
     |
     | GET /{route}?from=2026-01-01&to=2026-01-31&limit=50&sort=asc&tags=music,art&organizer={id}
     |
+    | To enrich occurrences with extra fields (image, category, anything
+    | derived from the entry), listen to the OccurrenceBuilding event. It
+    | fires once per occurrence at cache rebuild — zero runtime cost on API
+    | reads. Recipe in the event's class docblock:
+    | ElSchneider\StatamicCalendar\Events\OccurrenceBuilding
+    |
     */
 
     'api' => [

--- a/config/statamic-calendar.php
+++ b/config/statamic-calendar.php
@@ -119,9 +119,9 @@ return [
     | GET /{route}?from=2026-01-01&to=2026-01-31&limit=50&sort=asc&tags=music,art&organizer={id}
     |
     | To enrich occurrences with extra fields (image, category, anything
-    | derived from the entry), listen to the OccurrenceBuilding event. It
-    | fires once per occurrence at cache rebuild — zero runtime cost on API
-    | reads. Recipe in the event's class docblock:
+    | derived from the entry or resolved occurrence), listen to the
+    | OccurrenceBuilding event. It fires once per occurrence at cache rebuild
+    | — zero runtime cost on API reads. Recipe in the event's class docblock:
     | ElSchneider\StatamicCalendar\Events\OccurrenceBuilding
     |
     */

--- a/src/Events/OccurrenceBuilding.php
+++ b/src/Events/OccurrenceBuilding.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ElSchneider\StatamicCalendar\Events;
 
+use ElSchneider\StatamicCalendar\Occurrences\Occurrence;
 use Statamic\Contracts\Entries\Entry;
 
 /**
@@ -12,7 +13,7 @@ use Statamic\Contracts\Entries\Entry;
  * on `OccurrenceData` and in API / tag output.
  *
  * Runs at cache build time only — zero cost on reads. Results are frozen
- * until the next rebuild; depend on entry data, not request context.
+ * until the next rebuild; depend on entry and occurrence data, not request context.
  *
  * Extra values must stay JSON-serializable (scalars, arrays, Arrayable).
  * Core occurrence fields always win on name collisions.
@@ -25,6 +26,7 @@ use Statamic\Contracts\Entries\Entry;
  *     Event::listen(OccurrenceBuilding::class, function (OccurrenceBuilding $e) {
  *         $e->extra['image'] = $e->entry->augmentedValue('image')->shallow()->value();
  *         $e->extra['category'] = $e->entry->get('category');
+ *         $e->extra['occurrence_date'] = $e->occurrence->start->toDateString();
  *     });
  */
 final class OccurrenceBuilding
@@ -34,6 +36,7 @@ final class OccurrenceBuilding
      */
     public function __construct(
         public readonly Entry $entry,
+        public readonly Occurrence $occurrence,
         public array $extra = [],
     ) {}
 }

--- a/src/Events/OccurrenceBuilding.php
+++ b/src/Events/OccurrenceBuilding.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ElSchneider\StatamicCalendar\Events;
+
+use Statamic\Contracts\Entries\Entry;
+
+/**
+ * Fired during occurrence cache rebuild, once per materialized occurrence,
+ * before the payload is stored. Listeners can add `$extra` fields that end up
+ * on `OccurrenceData` and in API / tag output.
+ *
+ * Runs at cache build time only — zero cost on reads. Results are frozen
+ * until the next rebuild; depend on entry data, not request context.
+ *
+ * Extra values must stay JSON-serializable (scalars, arrays, Arrayable).
+ * Core occurrence fields always win on name collisions.
+ *
+ * Example:
+ *
+ *     use ElSchneider\StatamicCalendar\Events\OccurrenceBuilding;
+ *     use Illuminate\Support\Facades\Event;
+ *
+ *     Event::listen(OccurrenceBuilding::class, function (OccurrenceBuilding $e) {
+ *         $e->extra['image'] = $e->entry->augmentedValue('image')->shallow()->value();
+ *         $e->extra['category'] = $e->entry->get('category');
+ *     });
+ */
+final class OccurrenceBuilding
+{
+    /**
+     * @param  array<string, mixed>  $extra
+     */
+    public function __construct(
+        public readonly Entry $entry,
+        public array $extra = [],
+    ) {}
+}

--- a/src/Occurrences/OccurrenceCache.php
+++ b/src/Occurrences/OccurrenceCache.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace ElSchneider\StatamicCalendar\Occurrences;
 
 use Carbon\Carbon;
+use ElSchneider\StatamicCalendar\Events\OccurrenceBuilding;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Statamic\Facades\Entry;
 
@@ -128,7 +130,7 @@ class OccurrenceCache
             $organizerData = $this->extractOrganizerData($entry);
 
             foreach ($eventOccurrences as $occurrence) {
-                $occurrences->push([
+                $payload = [
                     'id' => OccurrenceData::composeId($entryId, $occurrence->start),
                     'entry_id' => $entryId,
                     'title' => (string) $entry->get('title'),
@@ -145,6 +147,14 @@ class OccurrenceCache
                     'is_recurring' => $occurrence->isRecurring,
                     'recurrence_description' => $occurrence->recurrenceDescription,
                     'url' => $occurrence->url(),
+                ];
+
+                $event = new OccurrenceBuilding($entry);
+                Event::dispatch($event);
+
+                $occurrences->push([
+                    ...$event->extra,
+                    ...$payload, // Core fields win on collisions.
                 ]);
             }
         }

--- a/src/Occurrences/OccurrenceCache.php
+++ b/src/Occurrences/OccurrenceCache.php
@@ -149,7 +149,7 @@ class OccurrenceCache
                     'url' => $occurrence->url(),
                 ];
 
-                $event = new OccurrenceBuilding($entry);
+                $event = new OccurrenceBuilding($entry, $occurrence);
                 Event::dispatch($event);
 
                 $occurrences->push([

--- a/src/Occurrences/OccurrenceData.php
+++ b/src/Occurrences/OccurrenceData.php
@@ -12,8 +12,34 @@ use Carbon\Carbon;
 readonly class OccurrenceData
 {
     /**
+     * Keys managed by the DTO itself. Anything else on a stored payload
+     * lands in `$extra` on rehydration.
+     */
+    private const RESERVED_KEYS = [
+        'id',
+        'entry_id',
+        'title',
+        'slug',
+        'teaser',
+        'organizer_id',
+        'organizer_slug',
+        'organizer_title',
+        'organizer_url',
+        'tags',
+        'start',
+        'end',
+        'is_all_day',
+        'is_recurring',
+        'recurrence_description',
+        'url',
+    ];
+
+    /**
      * @param  string|null  $teaser  Short description for listing views
      * @param  array<string>  $tags  Tag slugs for filtering
+     * @param  array<string, mixed>  $extra  Extra fields contributed by `OccurrenceBuilding`
+     *                                       listeners at cache build time. Splatted onto `toArray()`
+     *                                       so they surface in API and tag output.
      */
     public function __construct(
         public string $id,
@@ -32,6 +58,7 @@ readonly class OccurrenceData
         public bool $isRecurring,
         public ?string $recurrenceDescription,
         public string $url,
+        public array $extra = [],
     ) {}
 
     /**
@@ -45,6 +72,8 @@ readonly class OccurrenceData
 
     public static function fromArray(array $data): self
     {
+        $extra = array_diff_key($data, array_flip(self::RESERVED_KEYS));
+
         return new self(
             id: (string) $data['id'],
             entryId: (string) $data['entry_id'],
@@ -62,12 +91,15 @@ readonly class OccurrenceData
             isRecurring: (bool) $data['is_recurring'],
             recurrenceDescription: $data['recurrence_description'] ?? null,
             url: $data['url'],
+            extra: $extra,
         );
     }
 
     public function toArray(): array
     {
+        // Reserved keys last: collisions from $extra get silently shadowed.
         return [
+            ...$this->extra,
             'id' => $this->id,
             'entry_id' => $this->entryId,
             'title' => $this->title,

--- a/src/Tags/Calendar.php
+++ b/src/Tags/Calendar.php
@@ -398,7 +398,9 @@ class Calendar extends Tags
 
     private function occurrenceDataToArray(OccurrenceData $occurrence): array
     {
+        // Reserved keys last: extras from OccurrenceBuilding listeners can't shadow core tag fields.
         return [
+            ...$occurrence->extra,
             'id' => $occurrence->entryId,
             'occurrence_id' => $occurrence->id,
             'title' => $occurrence->title,

--- a/tests/Feature/CalendarTagTest.php
+++ b/tests/Feature/CalendarTagTest.php
@@ -12,24 +12,7 @@ beforeEach(function () {
     Carbon::setTestNow('2026-02-01 00:00:00');
 
     $this->tagOccurrences = collect([
-        OccurrenceData::fromArray([
-            'id' => 'aaa-2026-02-05-100000',
-            'entry_id' => 'aaa',
-            'title' => 'Event A',
-            'slug' => 'event-a',
-            'teaser' => null,
-            'organizer_id' => null,
-            'organizer_slug' => null,
-            'organizer_title' => null,
-            'organizer_url' => null,
-            'tags' => [],
-            'start' => '2026-02-05T10:00:00+00:00',
-            'end' => '2026-02-05T11:00:00+00:00',
-            'is_all_day' => false,
-            'is_recurring' => false,
-            'recurrence_description' => null,
-            'url' => '/events/event-a',
-        ]),
+        calendarTagOccurrence(),
     ]);
 
     $mock = Mockery::mock(OccurrenceCache::class);
@@ -54,6 +37,28 @@ function calendarTag(array $params = [], array $context = []): Calendar
     return $tag;
 }
 
+function calendarTagOccurrence(array $overrides = []): OccurrenceData
+{
+    return OccurrenceData::fromArray(array_merge([
+        'id' => 'aaa-2026-02-05-100000',
+        'entry_id' => 'aaa',
+        'title' => 'Event A',
+        'slug' => 'event-a',
+        'teaser' => null,
+        'organizer_id' => null,
+        'organizer_slug' => null,
+        'organizer_title' => null,
+        'organizer_url' => null,
+        'tags' => [],
+        'start' => '2026-02-05T10:00:00+00:00',
+        'end' => '2026-02-05T11:00:00+00:00',
+        'is_all_day' => false,
+        'is_recurring' => false,
+        'recurrence_description' => null,
+        'url' => '/events/event-a',
+    ], $overrides));
+}
+
 test('loop items expose composed occurrence_id alongside entry id', function () {
     $result = calendarTag(['from' => '2026-02-01'])->index();
 
@@ -70,6 +75,24 @@ test('ics_download_url uses context occurrence_id when present', function () {
     );
 
     expect($tag->icsDownloadUrl())->toContain('aaa-2026-02-05-100000');
+});
+
+test('loop items surface extras contributed by OccurrenceBuilding listeners', function () {
+    $this->tagOccurrences = collect([
+        calendarTagOccurrence([
+            'image' => ['url' => '/assets/a.jpg'],
+            'category' => 'music',
+        ]),
+    ]);
+    $mock = Mockery::mock(OccurrenceCache::class);
+    $mock->shouldReceive('all')->andReturn($this->tagOccurrences);
+    $this->app->instance(OccurrenceCache::class, $mock);
+
+    $item = collect(calendarTag(['from' => '2026-02-01'])->index())->first();
+
+    expect($item['image'])->toBe(['url' => '/assets/a.jpg'])
+        ->and($item['category'])->toBe('music')
+        ->and($item['title'])->toBe('Event A');
 });
 
 test('ics_download_url falls back to context id when occurrence_id absent', function () {

--- a/tests/Feature/OccurrenceBuildingEventTest.php
+++ b/tests/Feature/OccurrenceBuildingEventTest.php
@@ -22,6 +22,7 @@ test('rebuild persists OccurrenceBuilding extras without letting them shadow cor
     Event::listen(OccurrenceBuilding::class, function (OccurrenceBuilding $e) {
         $e->extra['image'] = ['url' => '/assets/foo.jpg'];
         $e->extra['category'] = $e->entry->slug();
+        $e->extra['occurrence_date'] = $e->occurrence->start->toDateString();
         $e->extra['title'] = 'Shadowed title';
     });
 
@@ -53,5 +54,6 @@ test('rebuild persists OccurrenceBuilding extras without letting them shadow cor
         ->and($occurrence->extra)->toBe([
             'image' => ['url' => '/assets/foo.jpg'],
             'category' => 'demo-event',
+            'occurrence_date' => '2026-03-10',
         ]);
 });

--- a/tests/Feature/OccurrenceBuildingEventTest.php
+++ b/tests/Feature/OccurrenceBuildingEventTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use ElSchneider\StatamicCalendar\Events\OccurrenceBuilding;
+use ElSchneider\StatamicCalendar\Occurrences\Occurrence;
+use ElSchneider\StatamicCalendar\Occurrences\OccurrenceCache;
+use ElSchneider\StatamicCalendar\Occurrences\OccurrenceResolver;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Statamic\Facades\Entry;
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-03-01 00:00:00');
+    Cache::flush();
+});
+
+afterEach(fn () => Carbon::setTestNow());
+
+test('rebuild persists OccurrenceBuilding extras without letting them shadow core fields', function () {
+    Event::listen(OccurrenceBuilding::class, function (OccurrenceBuilding $e) {
+        $e->extra['image'] = ['url' => '/assets/foo.jpg'];
+        $e->extra['category'] = $e->entry->slug();
+        $e->extra['title'] = 'Shadowed title';
+    });
+
+    // Occurrence::__construct types $entry as the concrete class, not the contract.
+    $entry = Mockery::mock(Statamic\Entries\Entry::class);
+    $entry->shouldReceive('id')->andReturn('entry-1');
+    $entry->shouldReceive('slug')->andReturn('demo-event');
+    $entry->shouldReceive('url')->andReturn('/events/demo-event');
+    $entry->shouldReceive('get')->with('dates')->andReturn([['start_date' => '2026-03-10']]);
+    $entry->shouldReceive('get')->with('title')->andReturn('Original title');
+    $entry->shouldReceive('get')->andReturn(null);
+
+    $builder = Mockery::mock();
+    $builder->shouldReceive('where')->andReturnSelf();
+    $builder->shouldReceive('get')->andReturn(collect([$entry]));
+    Entry::shouldReceive('query')->andReturn($builder);
+
+    $resolver = Mockery::mock(OccurrenceResolver::class);
+    $resolver->shouldReceive('resolve')->andReturn(collect([
+        new Occurrence($entry, Carbon::parse('2026-03-10 10:00'), null, false, false),
+    ]));
+    app()->instance(OccurrenceResolver::class, $resolver);
+
+    app(OccurrenceCache::class)->rebuild();
+
+    $occurrence = app(OccurrenceCache::class)->all()->first();
+
+    expect($occurrence->title)->toBe('Original title')
+        ->and($occurrence->extra)->toBe([
+            'image' => ['url' => '/assets/foo.jpg'],
+            'category' => 'demo-event',
+        ]);
+});

--- a/tests/Unit/OccurrenceDataTest.php
+++ b/tests/Unit/OccurrenceDataTest.php
@@ -41,6 +41,46 @@ test('OccurrenceData can be created from array and serialized back', function ()
     expect($array['id'])->toBe('abc-123-2026-03-06-150000');
 });
 
+test('fromArray collects non-reserved keys into $extra and toArray splats them', function () {
+    $occurrence = OccurrenceData::fromArray([...baseOccurrenceArray(), 'image' => 'foo.jpg', 'category' => 'music']);
+
+    expect($occurrence->extra)->toBe(['image' => 'foo.jpg', 'category' => 'music'])
+        ->and($occurrence->toArray()['image'])->toBe('foo.jpg');
+});
+
+test('fromArray strips reserved keys from $extra so core fields cannot be shadowed', function () {
+    $occurrence = OccurrenceData::fromArray([
+        ...baseOccurrenceArray(),
+        'title' => 'Real title',
+        'image' => 'ok',
+    ]);
+
+    expect($occurrence->extra)->toBe(['image' => 'ok'])
+        ->and($occurrence->toArray()['title'])->toBe('Real title');
+});
+
+function baseOccurrenceArray(): array
+{
+    return [
+        'id' => 'abc-2026-03-06-150000',
+        'entry_id' => 'abc',
+        'title' => 'Base',
+        'slug' => 'base',
+        'teaser' => null,
+        'organizer_id' => null,
+        'organizer_slug' => null,
+        'organizer_title' => null,
+        'organizer_url' => null,
+        'tags' => [],
+        'start' => '2026-03-06T15:00:00+00:00',
+        'end' => null,
+        'is_all_day' => false,
+        'is_recurring' => false,
+        'recurrence_description' => null,
+        'url' => '/events/base',
+    ];
+}
+
 test('OccurrenceData normalizes numeric ids to strings', function () {
     $occurrence = OccurrenceData::fromArray([
         'id' => '1-2026-03-06-150000',


### PR DESCRIPTION
## Summary
- add `OccurrenceBuilding` cache-build event for enriching occurrences with extra fields
- persist extras through `OccurrenceData`, API output, and calendar tag output
- prevent extras from shadowing core occurrence fields

## Test Plan
- [x] `./vendor/bin/pest`
- [x] `./vendor/bin/pint --test src/Events/OccurrenceBuilding.php src/Occurrences/OccurrenceCache.php src/Occurrences/OccurrenceData.php src/Tags/Calendar.php tests/Feature/CalendarTagTest.php tests/Feature/OccurrenceBuildingEventTest.php tests/Unit/OccurrenceDataTest.php`
- [x] v6 sandbox tinker listener: cache rebuild persisted `sandbox_probe` extra and kept original `title`
- [x] v6 sandbox calendar tag returned cached `sandbox_probe` extra
- [x] v6 sandbox cache rebuilt afterward to remove probe data
