### PR TITLE
fix: exclude unpublished event entries

### DIFF
--- a/src/Http/Controllers/OccurrenceController.php
+++ b/src/Http/Controllers/OccurrenceController.php
@@ -26,7 +26,7 @@ class OccurrenceController
             ->where('slug', $slug)
             ->first();
 
-        if (! $entry) {
+        if (! $entry || ! $entry->published()) {
             abort(404);
         }
 

--- a/src/Occurrences/OccurrenceCache.php
+++ b/src/Occurrences/OccurrenceCache.php
@@ -108,6 +108,10 @@ class OccurrenceCache
         $occurrences = collect();
 
         foreach ($entries as $entry) {
+            if (! $entry->published()) {
+                continue;
+            }
+
             $dates = $entry->get($this->datesField()) ?? [];
 
             if (empty($dates)) {

--- a/src/Tags/Calendar.php
+++ b/src/Tags/Calendar.php
@@ -66,7 +66,7 @@ class Calendar extends Tags
 
         $entry = (is_string($entryId) || is_int($entryId)) ? Entry::find((string) $entryId) : null;
 
-        if (! $entry || ! $dateString) {
+        if (! $entry || ! $entry->published() || ! $dateString) {
             return '';
         }
 
@@ -199,7 +199,7 @@ class Calendar extends Tags
         $entryId = $this->params->get('entry') ?? $this->context->get('id');
         $entry = (is_string($entryId) || is_int($entryId)) ? Entry::find((string) $entryId) : null;
 
-        if (! $entry) {
+        if (! $entry || ! $entry->published()) {
             return [];
         }
 
@@ -418,6 +418,10 @@ class Calendar extends Tags
         $resolverLimit = $paginate > 0 ? null : $limit;
 
         foreach ($entries as $entry) {
+            if (! $entry->published()) {
+                continue;
+            }
+
             $occurrences = $this->resolver->resolve($entry, $from, $to, $resolverLimit);
             $allOccurrences = $allOccurrences->merge($occurrences);
         }

--- a/tests/Feature/OccurrenceBuildingEventTest.php
+++ b/tests/Feature/OccurrenceBuildingEventTest.php
@@ -18,6 +18,40 @@ beforeEach(function () {
 
 afterEach(fn () => Carbon::setTestNow());
 
+test('rebuild skips unpublished entries', function () {
+    $publishedEntry = Mockery::mock(Statamic\Entries\Entry::class);
+    $publishedEntry->shouldReceive('published')->andReturnTrue();
+    $publishedEntry->shouldReceive('id')->andReturn('published-entry');
+    $publishedEntry->shouldReceive('slug')->andReturn('published-event');
+    $publishedEntry->shouldReceive('url')->andReturn('/events/published-event');
+    $publishedEntry->shouldReceive('get')->with('dates')->andReturn([['start_date' => '2026-03-10']]);
+    $publishedEntry->shouldReceive('get')->with('title')->andReturn('Published event');
+    $publishedEntry->shouldReceive('get')->andReturn(null);
+
+    $draftEntry = Mockery::mock(Statamic\Entries\Entry::class);
+    $draftEntry->shouldReceive('published')->andReturnFalse();
+
+    $builder = Mockery::mock();
+    $builder->shouldReceive('where')->andReturnSelf();
+    $builder->shouldReceive('get')->andReturn(collect([$publishedEntry, $draftEntry]));
+    Entry::shouldReceive('query')->andReturn($builder);
+
+    $resolver = Mockery::mock(OccurrenceResolver::class);
+    $resolver->shouldReceive('resolve')
+        ->once()
+        ->with($publishedEntry, Mockery::type(Carbon::class), Mockery::type(Carbon::class))
+        ->andReturn(collect([
+            new Occurrence($publishedEntry, Carbon::parse('2026-03-10 10:00'), null, false, false),
+        ]));
+    app()->instance(OccurrenceResolver::class, $resolver);
+
+    app(OccurrenceCache::class)->rebuild();
+
+    expect(app(OccurrenceCache::class)->all())
+        ->toHaveCount(1)
+        ->first()->title->toBe('Published event');
+});
+
 test('rebuild persists OccurrenceBuilding extras without letting them shadow core fields', function () {
     Event::listen(OccurrenceBuilding::class, function (OccurrenceBuilding $e) {
         $e->extra['image'] = ['url' => '/assets/foo.jpg'];
@@ -29,6 +63,7 @@ test('rebuild persists OccurrenceBuilding extras without letting them shadow cor
     // Occurrence::__construct types $entry as the concrete class, not the contract.
     $entry = Mockery::mock(Statamic\Entries\Entry::class);
     $entry->shouldReceive('id')->andReturn('entry-1');
+    $entry->shouldReceive('published')->andReturnTrue();
     $entry->shouldReceive('slug')->andReturn('demo-event');
     $entry->shouldReceive('url')->andReturn('/events/demo-event');
     $entry->shouldReceive('get')->with('dates')->andReturn([['start_date' => '2026-03-10']]);

--- a/tests/Feature/OccurrenceControllerTest.php
+++ b/tests/Feature/OccurrenceControllerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use ElSchneider\StatamicCalendar\Http\Controllers\OccurrenceController;
+use ElSchneider\StatamicCalendar\Occurrences\OccurrenceResolver;
+use Statamic\Facades\Entry;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+test('occurrence route aborts for unpublished entries', function () {
+    $entry = Mockery::mock(Statamic\Entries\Entry::class);
+    $entry->shouldReceive('published')->andReturnFalse();
+
+    $builder = Mockery::mock();
+    $builder->shouldReceive('where')->with('collection', 'events')->andReturnSelf();
+    $builder->shouldReceive('where')->with('slug', 'draft-event')->andReturnSelf();
+    $builder->shouldReceive('first')->andReturn($entry);
+    Entry::shouldReceive('query')->andReturn($builder);
+
+    $controller = new OccurrenceController(Mockery::mock(OccurrenceResolver::class));
+
+    expect(fn () => $controller->show(2026, 3, 10, 'draft-event'))
+        ->toThrow(NotFoundHttpException::class);
+});


### PR DESCRIPTION
## Summary
- skip unpublished entries when rebuilding occurrence cache
- prevent unpublished entries from resolving through occurrence routes and live tag/resolver paths
- add regressions for cache rebuild and occurrence route behavior

## Verification
- vendor/bin/pest --compact
- vendor/bin/pint --test
- composer test --no-interaction in sjr.statamic with addon symlinked
- rebuilt occurrence cache in sjr.statamic; draft event cached_count=0, occurrence URL returns 404, homepage contains 0 draft slugs