### PR TITLE
fix: resolve event dates in the configured timezone (Statamic 6)

### DIFF
--- a/config/statamic-calendar.php
+++ b/config/statamic-calendar.php
@@ -16,6 +16,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Timezone
+    |--------------------------------------------------------------------------
+    |
+    | The timezone events are authored and displayed in. Stored date-field
+    | values are app-timezone instants (Statamic 6); occurrences are resolved
+    | in this timezone so wall-clock times and DST are handled correctly, and
+    | returned Carbons stay in it (matching Statamic's display-timezone
+    | contract). When null, falls back to statamic.system.display_timezone,
+    | then app.timezone, then UTC. Set this to the timezone editors author
+    | entries in (their Control Panel / browser timezone) so the stored
+    | instant maps back to the day they picked. For single-timezone sites,
+    | pin statamic/cp.php default_timezone to the same value.
+    |
+    */
+
+    'timezone' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Field Mapping
     |--------------------------------------------------------------------------
     |

--- a/pint.json
+++ b/pint.json
@@ -13,7 +13,6 @@
             "import_constants": true,
             "import_functions": true
         },
-        "mb_str_functions": true,
         "modernize_types_casting": true,
         "new_with_parentheses": false,
         "no_superfluous_elseif": true,

--- a/src/Occurrences/Occurrence.php
+++ b/src/Occurrences/Occurrence.php
@@ -32,7 +32,7 @@ class Occurrence
             return $this->entry->url().$separator.urlencode($param).'='.urlencode($this->start->format($format));
         }
 
-        $prefix = mb_trim((string) $this->cfg('statamic-calendar.url.date_segments.prefix', 'calendar'), '/');
+        $prefix = trim((string) $this->cfg('statamic-calendar.url.date_segments.prefix', 'calendar'), '/');
 
         return sprintf(
             '/%s/%s/%s/%s/%s',

--- a/src/Occurrences/OccurrenceResolver.php
+++ b/src/Occurrences/OccurrenceResolver.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace ElSchneider\StatamicCalendar\Occurrences;
 
 use Carbon\Carbon;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use Illuminate\Support\Collection;
 use RRule\RRule;
 use RRule\RSet;
@@ -37,8 +40,9 @@ class OccurrenceResolver
 
     public function findOccurrenceOnDate(Entry $entry, Carbon $date): ?Occurrence
     {
-        $startOfDay = $date->copy()->startOfDay();
-        $endOfDay = $date->copy()->endOfDay();
+        $tz = $this->timezone();
+        $startOfDay = $date->copy()->setTimezone($tz)->startOfDay();
+        $endOfDay = $date->copy()->setTimezone($tz)->endOfDay();
 
         $occurrences = $this->resolve(
             entry: $entry,
@@ -46,8 +50,8 @@ class OccurrenceResolver
             to: $endOfDay,
         );
 
-        return $occurrences->first(function (Occurrence $o) use ($date) {
-            return $o->start->isSameDay($date);
+        return $occurrences->first(function (Occurrence $o) use ($date, $tz) {
+            return $o->start->isSameDay($date->copy()->setTimezone($tz));
         });
     }
 
@@ -70,6 +74,12 @@ class OccurrenceResolver
 
         $rruleParams = $this->buildRruleParams($row);
 
+        if ($rruleParams === null) {
+            return collect();
+        }
+
+        $tz = new DateTimeZone($this->timezone());
+
         $rset = new RSet;
         $rset->addRRule($rruleParams);
 
@@ -78,14 +88,16 @@ class OccurrenceResolver
                 continue;
             }
 
-            $exdate = (string) $exclusion['date'];
-            if (! empty($exclusion['time'])) {
-                $exdate .= ' '.(string) $exclusion['time'];
-            } else {
-                $exdate .= ' '.(string) ($row['start_time'] ?? '00:00');
+            $day = $this->localDate($exclusion['date']);
+            if (! $day) {
+                continue;
             }
 
-            $rset->addExDate($exdate);
+            $time = $this->localTime($exclusion['time'] ?? null)
+                ?? $this->localTime($row['start_time'] ?? null)
+                ?? '00:00';
+
+            $rset->addExDate(new DateTimeImmutable($day.' '.$time, $tz));
         }
 
         foreach (($row['additions'] ?? []) as $addition) {
@@ -93,11 +105,14 @@ class OccurrenceResolver
                 continue;
             }
 
-            $rdate = (string) $addition['date'];
-            if (! empty($addition['start_time'])) {
-                $rdate .= ' '.(string) $addition['start_time'];
+            $day = $this->localDate($addition['date']);
+            if (! $day) {
+                continue;
             }
-            $rset->addDate($rdate);
+
+            $time = $this->localTime($addition['start_time'] ?? null) ?? '00:00';
+
+            $rset->addDate(new DateTimeImmutable($day.' '.$time, $tz));
         }
 
         $occurrences = collect();
@@ -147,10 +162,14 @@ class OccurrenceResolver
                 continue;
             }
 
-            $additionDate = Carbon::parse((string) $addition['date']);
-            if (! empty($addition['start_time'])) {
-                $additionDate->setTimeFromTimeString((string) $addition['start_time']);
+            $day = $this->localDate($addition['date']);
+            if (! $day) {
+                continue;
             }
+
+            $time = $this->localTime($addition['start_time'] ?? null) ?? '00:00';
+            $additionDate = Carbon::parse($day.' '.$time, $this->timezone());
+
             if ($additionDate->equalTo($date)) {
                 return $addition['end_time'] ?? null;
             }
@@ -159,15 +178,22 @@ class OccurrenceResolver
         return null;
     }
 
-    private function buildRruleParams(array $row): array
+    private function buildRruleParams(array $row): ?array
     {
-        $frequency = $row['frequency'];
-        $startTime = (string) ($row['start_time'] ?? '00:00');
+        $frequency = $row['frequency'] ?? null;
+        $day = $this->localDate($row['start_date'] ?? null);
+
+        if (! $frequency || ! $day) {
+            return null;
+        }
+
+        $tz = new DateTimeZone($this->timezone());
+        $startTime = $this->localTime($row['start_time'] ?? null) ?? '00:00';
 
         $params = [
             'FREQ' => $frequency,
             'INTERVAL' => $row['interval'] ?? 1,
-            'DTSTART' => $row['start_date'].' '.$startTime,
+            'DTSTART' => new DateTimeImmutable($day.' '.$startTime, $tz),
         ];
 
         if ($frequency === 'WEEKLY' && ! empty($row['weekdays'])) {
@@ -189,7 +215,10 @@ class OccurrenceResolver
             $params['COUNT'] = $row['count'];
         }
         if ($recurrenceEnd === 'until' && ! empty($row['until'])) {
-            $params['UNTIL'] = $row['until'];
+            $untilDay = $this->localDate($row['until']);
+            if ($untilDay) {
+                $params['UNTIL'] = new DateTimeImmutable($untilDay.' 23:59:59', $tz);
+            }
         }
 
         return $params;
@@ -197,8 +226,8 @@ class OccurrenceResolver
 
     private function resolveSingleDate(Entry $entry, array $row, Carbon $from, ?Carbon $to): Collection
     {
-        $start = $this->parseDateTime($row['start_date'] ?? null, $row['start_time'] ?? null);
-        $end = $this->parseDateTime($row['end_date'] ?? null, $row['end_time'] ?? null);
+        $start = $this->localDateTime($row['start_date'] ?? null, $row['start_time'] ?? null);
+        $end = $this->localDateTime($row['end_date'] ?? null, $row['end_time'] ?? null);
 
         if (! $start) {
             return collect();
@@ -219,24 +248,77 @@ class OccurrenceResolver
         ]);
     }
 
-    private function parseDateTime(?string $date, ?string $time): ?Carbon
+    /**
+     * The timezone events are authored and displayed in. Statamic 6 stores
+     * date-field values as app-timezone instants; recurrence and wall-clock
+     * times are computed in this timezone so DST is handled correctly. The
+     * returned Carbons stay in this timezone, matching Statamic's
+     * display-timezone contract (templates localize via modifiers).
+     */
+    private function timezone(): string
     {
-        if (! $date) {
+        return (string) (
+            config('statamic-calendar.timezone')
+            ?: config('statamic.system.display_timezone')
+            ?: config('app.timezone')
+            ?: 'UTC'
+        );
+    }
+
+    /**
+     * Recover the wall-clock calendar day (Y-m-d) the editor picked. Statamic 6
+     * stores date fields as the instant — in the app timezone — of midnight in
+     * the editor's timezone, so we convert back to the event timezone before
+     * reading the day. Tolerates both date-only and datetime stored values.
+     */
+    private function localDate(mixed $value): ?string
+    {
+        if (blank($value)) {
             return null;
         }
 
-        $datetime = Carbon::parse($date);
+        return Carbon::parse((string) $value, config('app.timezone'))
+            ->setTimezone($this->timezone())
+            ->format('Y-m-d');
+    }
 
-        if ($time) {
-            $datetime->setTimeFromTimeString($time);
+    /**
+     * Validate and return an "HH:MM" (optionally "HH:MM:SS") wall-clock time.
+     * Anything blank or malformed returns null so callers fall back to a safe
+     * default instead of letting a bad stored value crash the cache rebuild.
+     */
+    private function localTime(mixed $value): ?string
+    {
+        $value = is_string($value) ? mb_trim($value) : '';
+
+        if (! preg_match('/^([01]?\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/', $value)) {
+            return null;
         }
 
-        return $datetime;
+        return $value;
+    }
+
+    /**
+     * Build a wall-clock Carbon in the event timezone from a stored date value
+     * and an optional "HH:MM" time string.
+     */
+    private function localDateTime(mixed $date, mixed $time): ?Carbon
+    {
+        if (! $day = $this->localDate($date)) {
+            return null;
+        }
+
+        return Carbon::parse($day.' '.($this->localTime($time) ?? '00:00'), $this->timezone());
     }
 
     private function buildRecurrenceDescription(array $row): string
     {
         $rruleParams = $this->buildRruleParams($row);
+
+        if ($rruleParams === null) {
+            return '';
+        }
+
         $rrule = new RRule($rruleParams);
 
         return $rrule->humanReadable([

--- a/src/Occurrences/OccurrenceResolver.php
+++ b/src/Occurrences/OccurrenceResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ElSchneider\StatamicCalendar\Occurrences;
 
 use Carbon\Carbon;
-use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use Illuminate\Support\Collection;
@@ -289,7 +288,7 @@ class OccurrenceResolver
      */
     private function localTime(mixed $value): ?string
     {
-        $value = is_string($value) ? mb_trim($value) : '';
+        $value = is_string($value) ? trim($value) : '';
 
         if (! preg_match('/^([01]?\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/', $value)) {
             return null;

--- a/tests/Feature/OccurrenceResolverTest.php
+++ b/tests/Feature/OccurrenceResolverTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use ElSchneider\StatamicCalendar\Occurrences\Occurrence;
+use ElSchneider\StatamicCalendar\Occurrences\OccurrenceResolver;
+use Statamic\Entries\Entry;
+
+/**
+ * Builds an entry whose `dates` grid returns the given rows. The resolver only
+ * reads `$entry->get('dates')`, so a mock is sufficient and keeps these tests
+ * free of the Stache.
+ */
+function entryWithDates(array $rows): Entry
+{
+    $entry = Mockery::mock(Entry::class);
+    $entry->shouldReceive('get')->with('dates')->andReturn($rows);
+
+    return $entry;
+}
+
+function resolveDates(array $rows, string $from = '2025-01-01', string $to = '2027-01-01'): Illuminate\Support\Collection
+{
+    return (new OccurrenceResolver)->resolve(
+        entryWithDates($rows),
+        Carbon::parse($from, 'UTC'),
+        Carbon::parse($to, 'UTC'),
+    );
+}
+
+beforeEach(function () {
+    // Single-site setup: dates stored in UTC, authored/displayed in Berlin.
+    config()->set('app.timezone', 'UTC');
+    config()->set('statamic.system.display_timezone', 'Europe/Berlin');
+    config()->set('statamic-calendar.timezone', null);
+});
+
+test('recurring row with a Statamic 6 datetime start_date does not crash (DTSTART regression)', function () {
+    // v6 stores date-only fields as "Y-m-d H:i" — the addon used to concat this
+    // with start_time, producing an invalid DTSTART that threw in php-rrule.
+    $occurrences = resolveDates([[
+        'start_date' => '2025-03-01 00:00',
+        'start_time' => '08:00',
+        'is_recurring' => true,
+        'frequency' => 'DAILY',
+        'interval' => 1,
+        'recurrence_end' => 'count',
+        'count' => 3,
+    ]]);
+
+    expect($occurrences)->toHaveCount(3);
+    expect($occurrences->first()->start->format('Y-m-d H:i'))->toBe('2025-03-01 08:00');
+    expect($occurrences->first()->start->getTimezone()->getName())->toBe('Europe/Berlin');
+});
+
+test('single date stored as a UTC instant resolves to the local calendar day (no off-by-one)', function () {
+    // Editor in Berlin picks 2026-12-05; Statamic stores midnight-Berlin as the
+    // UTC instant 2026-12-04 23:00. The occurrence must land on Dec 5, not Dec 4.
+    $occurrences = resolveDates([[
+        'start_date' => '2026-12-04 23:00',
+        'start_time' => '09:00',
+        'is_recurring' => false,
+    ]]);
+
+    expect($occurrences)->toHaveCount(1);
+    expect($occurrences->first()->start->format('Y-m-d H:i'))->toBe('2026-12-05 09:00');
+});
+
+test('recurring occurrences keep their wall-clock time across a DST transition', function () {
+    // EU springs forward on 2025-03-30. A daily 09:00 event must stay 09:00 local
+    // before and after the switch (instant shifts, wall time does not).
+    $occurrences = resolveDates([[
+        'start_date' => '2025-03-28',
+        'start_time' => '09:00',
+        'is_recurring' => true,
+        'frequency' => 'DAILY',
+        'interval' => 1,
+        'recurrence_end' => 'count',
+        'count' => 5,
+    ]]);
+
+    $before = $occurrences->first(fn (Occurrence $o) => $o->start->format('Y-m-d') === '2025-03-28');
+    $after = $occurrences->first(fn (Occurrence $o) => $o->start->format('Y-m-d') === '2025-03-31');
+
+    expect($before->start->format('H:i'))->toBe('09:00');
+    expect($before->start->format('P'))->toBe('+01:00');
+    expect($after->start->format('H:i'))->toBe('09:00');
+    expect($after->start->format('P'))->toBe('+02:00');
+});
+
+test('UNTIL is interpreted in the event timezone and is inclusive of the final day', function () {
+    $occurrences = resolveDates([[
+        'start_date' => '2025-06-01',
+        'start_time' => '10:00',
+        'is_recurring' => true,
+        'frequency' => 'DAILY',
+        'interval' => 1,
+        'recurrence_end' => 'until',
+        'until' => '2025-06-03',
+    ]]);
+
+    expect($occurrences->map(fn (Occurrence $o) => $o->start->format('Y-m-d'))->all())
+        ->toBe(['2025-06-01', '2025-06-02', '2025-06-03']);
+});
+
+test('exclusions drop the matching local day', function () {
+    $occurrences = resolveDates([[
+        'start_date' => '2025-06-01',
+        'start_time' => '10:00',
+        'is_recurring' => true,
+        'frequency' => 'DAILY',
+        'interval' => 1,
+        'recurrence_end' => 'count',
+        'count' => 3,
+        'exclusions' => [
+            ['date' => '2025-06-02'],
+        ],
+    ]]);
+
+    expect($occurrences->map(fn (Occurrence $o) => $o->start->format('Y-m-d'))->all())
+        ->toBe(['2025-06-01', '2025-06-03']);
+});
+
+test('recurring row missing start_date yields nothing instead of crashing', function () {
+    expect(resolveDates([[
+        'is_recurring' => true,
+        'frequency' => 'WEEKLY',
+    ]]))->toHaveCount(0);
+});
+
+test('recurring row missing frequency yields nothing instead of crashing', function () {
+    expect(resolveDates([[
+        'start_date' => '2025-06-01',
+        'start_time' => '10:00',
+        'is_recurring' => true,
+    ]]))->toHaveCount(0);
+});
+
+test('a malformed start_time falls back to midnight instead of crashing the rebuild', function () {
+    $occurrences = resolveDates([[
+        'start_date' => '2025-06-01',
+        'start_time' => '25:99',
+        'is_recurring' => true,
+        'frequency' => 'DAILY',
+        'interval' => 1,
+        'recurrence_end' => 'count',
+        'count' => 2,
+    ]]);
+
+    expect($occurrences)->toHaveCount(2);
+    expect($occurrences->first()->start->format('Y-m-d H:i'))->toBe('2025-06-01 00:00');
+});


### PR DESCRIPTION
## Problem

Statamic 6 stores date fields as the UTC instant of the editor's selected midnight (in the app timezone), so a date-only `start_date` now carries a time component.

This caused two bugs:

1. **Crash on save.** `buildRruleParams()` concatenated `start_date . ' ' . start_time`, producing a malformed `DTSTART` (`2025-03-01 00:00 08:00`) that threw `InvalidArgumentException` in php-rrule. Because the occurrence cache rebuilds on every entry save, a single recurring event made *every* save fail.
2. **Off-by-one day.** The raw stored string was read as a wall-clock day, so events appeared one day early in timezones ahead of UTC.

## Fix

- Interpret stored dates in an explicit **event timezone** — new `statamic-calendar.timezone` config, falling back to `statamic.system.display_timezone`, then `app.timezone`, then UTC.
- Recover the calendar day by converting the stored instant back to the event timezone.
- Build recurrence (`DTSTART` / `UNTIL` / `EXDATE` / `RDATE`) from `DateTime` objects in the event timezone so php-rrule expands DST-correctly.
- Return occurrences in the event timezone, matching Statamic's display-timezone contract (templates localize via modifiers).
- Guard half-filled rows: a missing `start_date`/`frequency` or a malformed time string no longer crashes the rebuild.

## Tests

Added resolver coverage: the `DTSTART` crash regression, UTC-instant → local-day extraction, DST wall-time stability, inclusive `UNTIL`, exclusions, missing-field guards, and malformed-time fallback.
