### PR TITLE
fix: support Statamic 6 in the test harness and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,13 @@ jobs:
       - run: vendor/bin/pint --test
 
   tests:
-    name: Tests – PHP ${{ matrix.php }}
+    name: Tests – PHP ${{ matrix.php }} / Statamic ${{ matrix.statamic }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
         php: ['8.3', '8.4']
+        statamic: ['^5.0', '^6.0']
     steps:
       - uses: actions/checkout@v4
 
@@ -48,6 +49,6 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
 
-      - run: composer install --no-interaction
+      - run: composer update --no-interaction --prefer-dist --with "statamic/cms:${{ matrix.statamic }}"
 
       - run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "statamic/cms": "^5.0 || ^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^9.0 || ^10.0",
         "pestphp/pest": "^4.3",
         "pestphp/pest-plugin-laravel": "^4.0",
         "laravel/pint": "^1.27"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,90 +5,21 @@ declare(strict_types=1);
 namespace ElSchneider\StatamicCalendar\Tests;
 
 use ElSchneider\StatamicCalendar\ServiceProvider;
-use Facades\Statamic\Version;
-use Orchestra\Testbench\TestCase as OrchestraTestCase;
-use ReflectionClass;
-use Statamic\Console\Processes\Composer;
-use Statamic\Extend\Manifest;
-use Statamic\Providers\StatamicServiceProvider;
-use Statamic\Statamic;
+use Statamic\Testing\AddonTestCase;
 
 /**
- * Custom TestCase mirroring Statamic's AddonTestCase but without the
- * addToAssertionCount(-1) calls that break on PHPUnit 12.
- *
- * @see \Statamic\Testing\AddonTestCase
+ * Extends Statamic's own AddonTestCase so addon registration (manifest,
+ * providers, stache stores) tracks each Statamic version — the `Manifest`
+ * class moved from `Statamic\Extend` (v5) to `Statamic\Addons` (v6), which a
+ * hand-rolled copy would have to special-case.
  */
-abstract class TestCase extends OrchestraTestCase
+abstract class TestCase extends AddonTestCase
 {
     protected string $addonServiceProvider = ServiceProvider::class;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->withoutMix();
-        $this->withoutVite();
-
-        Version::shouldReceive('get')->zeroOrMoreTimes()
-            ->andReturn(Composer::create(__DIR__.'/../vendor/statamic/cms/')->installedVersion(Statamic::PACKAGE));
-
-        \Statamic\Facades\CP\Nav::shouldReceive('build')->zeroOrMoreTimes()->andReturn(collect());
-        \Statamic\Facades\CP\Nav::shouldReceive('clearCachedUrls')->zeroOrMoreTimes();
-    }
-
-    protected function getPackageProviders($app): array
-    {
-        return [
-            StatamicServiceProvider::class,
-            $this->addonServiceProvider,
-        ];
-    }
-
-    protected function getPackageAliases($app): array
-    {
-        return ['Statamic' => Statamic::class];
-    }
 
     protected function getEnvironmentSetUp($app): void
     {
         parent::getEnvironmentSetUp($app);
-
-        $reflector = new ReflectionClass($this->addonServiceProvider);
-        $directory = dirname($reflector->getFileName());
-
-        $providerParts = explode('\\', $this->addonServiceProvider, -1);
-        $namespace = implode('\\', $providerParts);
-
-        $json = json_decode($app['files']->get($directory.'/../composer.json'), true);
-        $statamic = $json['extra']['statamic'] ?? [];
-        $autoload = $json['autoload']['psr-4'][$namespace.'\\'];
-
-        $app->make(Manifest::class)->manifest = [
-            $json['name'] => [
-                'id' => $json['name'],
-                'slug' => $statamic['slug'] ?? null,
-                'version' => 'dev-main',
-                'namespace' => $namespace,
-                'autoload' => $autoload,
-                'provider' => $this->addonServiceProvider,
-            ],
-        ];
-
-        $app['config']->set('statamic.users.repository', 'file');
-        $app['config']->set('statamic.stache.watcher', false);
-        $app['config']->set('statamic.stache.stores.taxonomies.directory', $directory.'/../tests/__fixtures__/content/taxonomies');
-        $app['config']->set('statamic.stache.stores.terms.directory', $directory.'/../tests/__fixtures__/content/taxonomies');
-        $app['config']->set('statamic.stache.stores.collections.directory', $directory.'/../tests/__fixtures__/content/collections');
-        $app['config']->set('statamic.stache.stores.entries.directory', $directory.'/../tests/__fixtures__/content/collections');
-        $app['config']->set('statamic.stache.stores.navigation.directory', $directory.'/../tests/__fixtures__/content/navigation');
-        $app['config']->set('statamic.stache.stores.globals.directory', $directory.'/../tests/__fixtures__/content/globals');
-        $app['config']->set('statamic.stache.stores.global-variables.directory', $directory.'/../tests/__fixtures__/content/globals');
-        $app['config']->set('statamic.stache.stores.asset-containers.directory', $directory.'/../tests/__fixtures__/content/assets');
-        $app['config']->set('statamic.stache.stores.nav-trees.directory', $directory.'/../tests/__fixtures__/content/structures/navigation');
-        $app['config']->set('statamic.stache.stores.collection-trees.directory', $directory.'/../tests/__fixtures__/content/structures/collections');
-        $app['config']->set('statamic.stache.stores.form-submissions.directory', $directory.'/../tests/__fixtures__/content/submissions');
-        $app['config']->set('statamic.stache.stores.users.directory', $directory.'/../tests/__fixtures__/users');
 
         $app['config']->set('statamic-calendar.api.enabled', true);
     }


### PR DESCRIPTION
## Problem

CI was red on `main`. There is no committed `composer.lock`, so CI always resolves dependencies fresh — and the ecosystem has since moved on:

- `orchestra/testbench ^9` caps Laravel at 11, but `statamic/cms ^6` requires Laravel 12 → the resolve deadlocks.
- Even once it resolves to Statamic 6, the hand-rolled `tests/TestCase.php` references `Statamic\Extend\Manifest`, which moved to `Statamic\Addons\Manifest` in v6 → `BindingResolutionException` in `setUp`.

## Fix

- Allow `orchestra/testbench ^9.0 || ^10.0` (testbench 10 = Laravel 12 = Statamic 6).
- Replace the forked `TestCase` with a thin subclass of Statamic's own `Statamic\Testing\AddonTestCase`, so manifest/provider/stache registration tracks each Statamic version instead of duplicating framework internals. (The fork existed to dodge a PHPUnit issue that no longer exists in the supported versions.)
- Expand the test matrix to run against **both** Statamic `^5.0` and `^6.0`.

## Verification

Full suite green locally against both `statamic/cms` v5.74 and v6.23 (50 passed). Pint and Prettier clean.
