### PR TITLE
feat: redirect expired occurrences and expose self-canonical occurrence URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,24 @@ Set the collection template to `events/show`, then create `resources/views/event
 
 The `{{ calendar:current_occurrence }}` tag reads the `?date=` query parameter and resolves the matching occurrence for the current entry. When using the `date_segments` strategy, the date is extracted from the URL instead.
 
+With the `date_segments` strategy, the occurrence controller also exposes the current occurrence directly to the show template: `start`, `end`, `is_all_day`, `is_recurring`, `recurrence_description`, `occurrence_url`, and `occurrence_canonical_url`. Compose SEO markup from those values plus your own blueprint fields:
+
+```antlers
+{{ push:head }}
+  <link rel="canonical" href="{{ occurrence_canonical_url }}">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Event",
+      "name": {{ title | to_json }},
+      "startDate": "{{ start format='c' }}",
+      {{ if end }}"endDate": "{{ end format='c' }}",{{ /if }}
+      "url": "{{ occurrence_canonical_url }}"
+    }
+  </script>
+{{ /push:head }}
+```
+
 ## Antlers Tags
 
 ### `{{ calendar }}`

--- a/config/statamic-calendar.php
+++ b/config/statamic-calendar.php
@@ -97,6 +97,13 @@ return [
     'url' => [
         'strategy' => 'query_string',
 
+        /*
+        | When date-segment occurrence URLs expire, redirect them to the next
+        | upcoming occurrence for the same entry. Ended series keep rendering
+        | their past occurrence pages.
+        */
+        'redirect_expired' => true,
+
         'query_string' => [
             'param' => 'date',
             'format' => 'Y-m-d',

--- a/config/statamic-calendar.php
+++ b/config/statamic-calendar.php
@@ -99,8 +99,8 @@ return [
 
         /*
         | When date-segment occurrence URLs expire, redirect them to the next
-        | upcoming occurrence for the same entry. Ended series keep rendering
-        | their past occurrence pages.
+        | upcoming occurrence for the same entry. If no successor exists, the
+        | past occurrence page keeps rendering.
         */
         'redirect_expired' => true,
 

--- a/src/Http/Controllers/OccurrenceController.php
+++ b/src/Http/Controllers/OccurrenceController.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use ElSchneider\StatamicCalendar\Facades\Occurrences;
 use ElSchneider\StatamicCalendar\Occurrences\OccurrenceData;
 use ElSchneider\StatamicCalendar\Occurrences\OccurrenceResolver;
+use Illuminate\Support\Collection;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\CP\LivePreview;
 use Statamic\Facades\Entry;
@@ -35,10 +36,13 @@ class OccurrenceController
 
         $date = Carbon::create($year, $month, $day);
 
-        $cachedOccurrence = $previewEntry
+        $cachedOccurrences = $previewEntry
             ? null
-            : Occurrences::forEntry($entry->id())
-                ->first(fn (OccurrenceData $o) => $o->start->isSameDay($date));
+            : Occurrences::forEntry($entry->id());
+
+        $cachedOccurrence = $cachedOccurrences
+            ? $cachedOccurrences->first(fn (OccurrenceData $o) => $o->start->isSameDay($date))
+            : null;
 
         if ($cachedOccurrence) {
             $occurrenceData = [
@@ -50,7 +54,7 @@ class OccurrenceController
                 'occurrence_url' => $cachedOccurrence->url,
             ];
 
-            if ($redirect = $this->redirectExpiredOccurrence($entry, $cachedOccurrence->start)) {
+            if ($redirect = $this->redirectExpiredOccurrence($entry, $cachedOccurrence->start, $cachedOccurrence->end, $cachedOccurrences)) {
                 return $redirect;
             }
 
@@ -63,7 +67,7 @@ class OccurrenceController
             abort(404);
         }
 
-        if ($redirect = $this->redirectExpiredOccurrence($entry, $occurrence->start)) {
+        if ($redirect = $this->redirectExpiredOccurrence($entry, $occurrence->start, $occurrence->end)) {
             return $redirect;
         }
 
@@ -94,7 +98,7 @@ class OccurrenceController
         return $entry;
     }
 
-    private function redirectExpiredOccurrence(EntryContract $entry, Carbon $occurrenceStart)
+    private function redirectExpiredOccurrence(EntryContract $entry, Carbon $occurrenceStart, ?Carbon $occurrenceEnd = null, ?Collection $cachedOccurrences = null)
     {
         if (! config('statamic-calendar.url.redirect_expired', true)) {
             return null;
@@ -104,17 +108,30 @@ class OccurrenceController
             return null;
         }
 
-        if ($occurrenceStart->copy()->endOfDay()->gte(Carbon::now($occurrenceStart->getTimezone()))) {
+        $now = Carbon::now($occurrenceStart->getTimezone());
+        $expiresAt = $occurrenceEnd ?? $occurrenceStart->copy()->endOfDay();
+
+        if ($expiresAt->gte($now)) {
             return null;
         }
 
-        $next = $this->resolver->nextUpcoming($entry);
+        $nextUrl = $cachedOccurrences
+            ? $this->nextCachedOccurrenceUrl($cachedOccurrences, $now)
+            : $this->resolver->nextUpcoming($entry)?->url();
 
-        if (! $next) {
+        if (! $nextUrl) {
             return null;
         }
 
-        return redirect()->to($this->absoluteOccurrenceUrl($entry, $next->url()), 301);
+        return redirect()->to($this->absoluteOccurrenceUrl($entry, $nextUrl), 301);
+    }
+
+    private function nextCachedOccurrenceUrl(Collection $cachedOccurrences, Carbon $from): ?string
+    {
+        return $cachedOccurrences
+            ->filter(fn (OccurrenceData $occurrence) => $occurrence->start->gte($from))
+            ->sortBy(fn (OccurrenceData $occurrence) => $occurrence->start)
+            ->first()?->url;
     }
 
     private function renderOccurrence($entry, array $occurrenceData)

--- a/src/Http/Controllers/OccurrenceController.php
+++ b/src/Http/Controllers/OccurrenceController.php
@@ -41,20 +41,30 @@ class OccurrenceController
                 ->first(fn (OccurrenceData $o) => $o->start->isSameDay($date));
 
         if ($cachedOccurrence) {
-            return $this->renderOccurrence($entry, [
+            $occurrenceData = [
                 'start' => $cachedOccurrence->start,
                 'end' => $cachedOccurrence->end,
                 'is_all_day' => $cachedOccurrence->isAllDay,
                 'is_recurring' => $cachedOccurrence->isRecurring,
                 'recurrence_description' => $cachedOccurrence->recurrenceDescription,
                 'occurrence_url' => $cachedOccurrence->url,
-            ]);
+            ];
+
+            if ($redirect = $this->redirectExpiredOccurrence($entry, $cachedOccurrence->start)) {
+                return $redirect;
+            }
+
+            return $this->renderOccurrence($entry, $occurrenceData);
         }
 
         $occurrence = $this->resolver->findOccurrenceOnDate($entry, $date);
 
         if (! $occurrence) {
             abort(404);
+        }
+
+        if ($redirect = $this->redirectExpiredOccurrence($entry, $occurrence->start)) {
+            return $redirect;
         }
 
         return $this->renderOccurrence($entry, [
@@ -84,13 +94,50 @@ class OccurrenceController
         return $entry;
     }
 
+    private function redirectExpiredOccurrence(EntryContract $entry, Carbon $occurrenceStart)
+    {
+        if (! config('statamic-calendar.url.redirect_expired', true)) {
+            return null;
+        }
+
+        if (request()->isLivePreview()) {
+            return null;
+        }
+
+        if ($occurrenceStart->copy()->endOfDay()->gte(Carbon::now($occurrenceStart->getTimezone()))) {
+            return null;
+        }
+
+        $next = $this->resolver->nextUpcoming($entry);
+
+        if (! $next) {
+            return null;
+        }
+
+        return redirect()->to($this->absoluteOccurrenceUrl($entry, $next->url()), 301);
+    }
+
     private function renderOccurrence($entry, array $occurrenceData)
     {
+        $occurrenceData['occurrence_canonical_url'] = $this->absoluteOccurrenceUrl(
+            $entry,
+            (string) $occurrenceData['occurrence_url'],
+        );
+
         $data = array_merge($entry->toAugmentedArray(), $occurrenceData);
 
         return (new View)
             ->template($entry->template())
             ->layout($entry->layout())
             ->with($data);
+    }
+
+    private function absoluteOccurrenceUrl(EntryContract $entry, string $url): string
+    {
+        if (str_starts_with($url, 'http://') || str_starts_with($url, 'https://')) {
+            return $url;
+        }
+
+        return rtrim($entry->site()->absoluteUrl(), '/').'/'.ltrim($url, '/');
     }
 }

--- a/src/Occurrences/OccurrenceResolver.php
+++ b/src/Occurrences/OccurrenceResolver.php
@@ -39,29 +39,20 @@ class OccurrenceResolver
     public function representative(Entry $entry): ?Occurrence
     {
         $now = Carbon::now($this->timezone());
-        $occurrences = collect();
+        $occurrences = $this->representativeCandidates($entry, $now);
 
-        foreach ($this->dates($entry) as $dateRow) {
-            if (! is_array($dateRow)) {
-                continue;
-            }
+        return $this->firstUpcoming($occurrences, $now)
+            ?? $occurrences->sortBy(fn (Occurrence $o) => $o->start)->last();
+    }
 
-            $occurrences = $occurrences->merge($this->resolveDateRow(
-                $entry,
-                $dateRow,
-                Carbon::create(1, 1, 1, 0, 0, 0, $this->timezone()),
-                null,
-                null,
-                representativeAt: $now,
-            ));
-        }
+    public function nextUpcoming(Entry $entry, ?Carbon $from = null): ?Occurrence
+    {
+        $from ??= Carbon::now($this->timezone());
 
-        $upcoming = $occurrences
-            ->filter(fn (Occurrence $o) => $o->start->gte($now))
-            ->sortBy(fn (Occurrence $o) => $o->start)
-            ->first();
-
-        return $upcoming ?? $occurrences->sortBy(fn (Occurrence $o) => $o->start)->last();
+        return $this->firstUpcoming(
+            $this->representativeCandidates($entry, $from),
+            $from,
+        );
     }
 
     public function findOccurrenceOnDate(Entry $entry, Carbon $date): ?Occurrence
@@ -79,6 +70,36 @@ class OccurrenceResolver
         return $occurrences->first(function (Occurrence $o) use ($date, $tz) {
             return $o->start->isSameDay($date->copy()->setTimezone($tz));
         });
+    }
+
+    private function representativeCandidates(Entry $entry, Carbon $at): Collection
+    {
+        $occurrences = collect();
+
+        foreach ($this->dates($entry) as $dateRow) {
+            if (! is_array($dateRow)) {
+                continue;
+            }
+
+            $occurrences = $occurrences->merge($this->resolveDateRow(
+                $entry,
+                $dateRow,
+                Carbon::create(1, 1, 1, 0, 0, 0, $this->timezone()),
+                null,
+                null,
+                representativeAt: $at,
+            ));
+        }
+
+        return $occurrences;
+    }
+
+    private function firstUpcoming(Collection $occurrences, Carbon $from): ?Occurrence
+    {
+        return $occurrences
+            ->filter(fn (Occurrence $o) => $o->start->gte($from))
+            ->sortBy(fn (Occurrence $o) => $o->start)
+            ->first();
     }
 
     private function resolveDateRow(Entry $entry, array $row, Carbon $from, ?Carbon $to, ?int $limit, ?Carbon $representativeAt = null): Collection

--- a/tests/Feature/OccurrenceControllerTest.php
+++ b/tests/Feature/OccurrenceControllerTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Carbon\Carbon;
+use ElSchneider\StatamicCalendar\Facades\Occurrences;
 use ElSchneider\StatamicCalendar\Http\Controllers\OccurrenceController;
 use ElSchneider\StatamicCalendar\Occurrences\OccurrenceResolver;
 use Illuminate\Http\Request;
@@ -12,10 +14,107 @@ use Statamic\Facades\Entry;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 afterEach(function () {
+    Carbon::setTestNow();
+    Occurrences::clear();
+
     File::delete([
         __DIR__.'/../__fixtures__/content/collections/events.yaml',
         __DIR__.'/../__fixtures__/content/collections/events/draft-event.md',
+        __DIR__.'/../__fixtures__/content/collections/events/past-with-successor.md',
+        __DIR__.'/../__fixtures__/content/collections/events/ended-series.md',
+        __DIR__.'/../__fixtures__/content/collections/events/future-event.md',
     ]);
+});
+
+function occurrenceControllerEntry(string $id, array $dates): Statamic\Contracts\Entries\Entry
+{
+    $collection = Collection::find('events') ?? Collection::make('events');
+    $collection->save();
+
+    $entry = Entry::make()
+        ->id($id)
+        ->collection($collection)
+        ->locale('default')
+        ->slug($id)
+        ->published(true)
+        ->template('statamic-calendar/show')
+        ->data([
+            'title' => str($id)->replace('-', ' ')->title()->toString(),
+            'dates' => $dates,
+        ]);
+
+    $entry->save();
+
+    return $entry;
+}
+
+test('past occurrence redirects to the next upcoming occurrence', function () {
+    Carbon::setTestNow('2026-07-11 12:00:00');
+    config()->set('statamic-calendar.url.strategy', 'date_segments');
+
+    occurrenceControllerEntry('past-with-successor', [[
+        'start_date' => '2026-07-04',
+        'start_time' => '10:00',
+        'is_recurring' => true,
+        'frequency' => 'weekly',
+    ]]);
+
+    $response = app(OccurrenceController::class)->show(2026, 7, 4, 'past-with-successor');
+
+    expect($response->getStatusCode())->toBe(301)
+        ->and($response->headers->get('Location'))->toBe('http://localhost/calendar/2026/07/18/past-with-successor');
+});
+
+test('past occurrence for ended series keeps rendering', function () {
+    Carbon::setTestNow('2026-07-11 12:00:00');
+    config()->set('statamic-calendar.url.strategy', 'date_segments');
+
+    occurrenceControllerEntry('ended-series', [[
+        'start_date' => '2026-07-04',
+        'start_time' => '10:00',
+        'is_recurring' => true,
+        'frequency' => 'weekly',
+        'recurrence_end' => 'count',
+        'count' => 1,
+    ]]);
+
+    $response = app(OccurrenceController::class)->show(2026, 7, 4, 'ended-series');
+
+    expect($response->data()['start']->toDateString())->toBe('2026-07-04')
+        ->and($response->data()['occurrence_url'])->toBe('/calendar/2026/07/04/ended-series');
+});
+
+test('past occurrence keeps rendering when expired redirects are disabled', function () {
+    Carbon::setTestNow('2026-07-11 12:00:00');
+    config()->set('statamic-calendar.url.strategy', 'date_segments');
+    config()->set('statamic-calendar.url.redirect_expired', false);
+
+    occurrenceControllerEntry('past-with-successor', [[
+        'start_date' => '2026-07-04',
+        'start_time' => '10:00',
+        'is_recurring' => true,
+        'frequency' => 'weekly',
+    ]]);
+
+    $response = app(OccurrenceController::class)->show(2026, 7, 4, 'past-with-successor');
+
+    expect($response->data()['start']->toDateString())->toBe('2026-07-04')
+        ->and($response->data()['occurrence_url'])->toBe('/calendar/2026/07/04/past-with-successor');
+});
+
+test('occurrence view data includes an absolute canonical url', function () {
+    Carbon::setTestNow('2026-07-11 12:00:00');
+    config()->set('statamic-calendar.url.strategy', 'date_segments');
+
+    occurrenceControllerEntry('future-event', [[
+        'start_date' => '2026-07-18',
+        'start_time' => '10:00',
+    ]]);
+
+    $response = app(OccurrenceController::class)->show(2026, 7, 18, 'future-event');
+
+    expect($response->data()['occurrence_url'])->toBe('/calendar/2026/07/18/future-event')
+        ->and($response->data()['occurrence_canonical_url'])->toBe('http://localhost/calendar/2026/07/18/future-event');
 });
 
 test('occurrence route renders tokenized unsaved preview values', function () {

--- a/tests/Feature/OccurrenceControllerTest.php
+++ b/tests/Feature/OccurrenceControllerTest.php
@@ -23,6 +23,7 @@ afterEach(function () {
         __DIR__.'/../__fixtures__/content/collections/events/past-with-successor.md',
         __DIR__.'/../__fixtures__/content/collections/events/ended-series.md',
         __DIR__.'/../__fixtures__/content/collections/events/future-event.md',
+        __DIR__.'/../__fixtures__/content/collections/events/today-event.md',
     ]);
 });
 
@@ -62,8 +63,28 @@ test('past occurrence redirects to the next upcoming occurrence', function () {
     $response = app(OccurrenceController::class)->show(2026, 7, 4, 'past-with-successor');
 
     expect($response->getStatusCode())->toBe(301)
-        ->and($response->headers->get('Location'))->toBe('http://localhost/calendar/2026/07/18/past-with-successor');
+        ->and(parse_url((string) $response->headers->get('Location'), PHP_URL_PATH))->toBe('/calendar/2026/07/18/past-with-successor');
 });
+
+it('renders today occurrences instead of redirecting expired URLs', function (string $startTime) {
+    Carbon::setTestNow('2026-07-11 12:00:00');
+    config()->set('statamic-calendar.url.strategy', 'date_segments');
+
+    occurrenceControllerEntry('today-event', [[
+        'start_date' => '2026-07-11',
+        'start_time' => $startTime,
+        'is_recurring' => true,
+        'frequency' => 'weekly',
+    ]]);
+
+    $response = app(OccurrenceController::class)->show(2026, 7, 11, 'today-event');
+
+    expect($response->data()['start']->toDateString())->toBe('2026-07-11')
+        ->and($response->data()['occurrence_url'])->toBe('/calendar/2026/07/11/today-event');
+})->with([
+    'started earlier today' => '10:00',
+    'starts later today' => '14:00',
+]);
 
 test('past occurrence for ended series keeps rendering', function () {
     Carbon::setTestNow('2026-07-11 12:00:00');
@@ -118,6 +139,7 @@ test('occurrence view data includes an absolute canonical url', function () {
 });
 
 test('occurrence route renders tokenized unsaved preview values', function () {
+    Carbon::setTestNow('2026-07-11 12:00:00');
     config()->set('statamic-calendar.url.strategy', 'date_segments');
 
     $collection = Collection::make('events');
@@ -132,28 +154,31 @@ test('occurrence route renders tokenized unsaved preview values', function () {
         ->template('statamic-calendar/show')
         ->data([
             'title' => 'Saved title',
-            'dates' => [['start_date' => '2026-07-01', 'start_time' => '10:00']],
+            'dates' => [['start_date' => '2026-08-03', 'start_time' => '10:00']],
         ]);
 
     $entry->setSupplement('title', 'Unsaved title');
-    $entry->setSupplement('dates', [
-        ['start_date' => '2026-08-03', 'start_time' => '10:00'],
-    ]);
+    $entry->setSupplement('dates', [[
+        'start_date' => '2026-07-04',
+        'start_time' => '10:00',
+        'is_recurring' => true,
+        'frequency' => 'weekly',
+    ]]);
 
     $token = app(LivePreview::class)->tokenize('calendar-preview-test', $entry);
 
     app()->instance('request', Request::create(
-        '/calendar/2026/08/03/draft-event',
+        '/calendar/2026/07/04/draft-event',
         'GET',
         ['token' => $token->token()],
     ));
 
-    $response = app(OccurrenceController::class)->show(2026, 8, 3, 'draft-event');
+    $response = app(OccurrenceController::class)->show(2026, 7, 4, 'draft-event');
 
     expect((string) $response->data()['title'])->toBe('Unsaved title')
-        ->and($response->data()['start']->toDateString())->toBe('2026-08-03');
+        ->and($response->data()['start']->toDateString())->toBe('2026-07-04');
 
-    expect(fn () => app(OccurrenceController::class)->show(2026, 8, 3, 'another-event'))
+    expect(fn () => app(OccurrenceController::class)->show(2026, 7, 4, 'another-event'))
         ->toThrow(NotFoundHttpException::class);
 });
 


### PR DESCRIPTION
## Motivation

Google's Event structured data guidance expects each event occurrence to have its own leaf URL, and canonical guidance recommends self-canonical URLs for distinct pages rather than consolidating different occurrences into one representative page.

- https://developers.google.com/search/docs/appearance/structured-data/event
- https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls

For date-segment occurrence URLs, past occurrences that have a clear successor should point crawlers and users at the next upcoming occurrence. Sites still own their Event JSON-LD because location, organizer, image, offers, and status usually come from site-specific blueprints.

## What changed

- Adds a configurable 301 redirect for expired date-segment occurrence URLs when the same entry has a next upcoming occurrence.
- Keeps past occurrence pages rendering when no successor exists, preserving archival behavior for ended series and single past events.
- Adds `occurrence_canonical_url` to occurrence show view data as an absolute self-canonical URL.
- Adds a resolver helper for the next upcoming occurrence.
- Documents a short Antlers example for composing canonical and Event JSON-LD markup from occurrence variables plus site blueprint fields.

## Config

```php
'url' => [
    'redirect_expired' => true,
],
```

Default is `true`. Set it to `false` to keep rendering past occurrence URLs even when a future successor exists.

## Example usage

```antlers
{{ push:head }}
  <link rel="canonical" href="{{ occurrence_canonical_url }}">
  <script type="application/ld+json">
    {
      "@context": "https://schema.org",
      "@type": "Event",
      "name": {{ title | to_json }},
      "startDate": "{{ start format='c' }}",
      {{ if end }}"endDate": "{{ end format='c' }}",{{ /if }}
      "url": "{{ occurrence_canonical_url }}"
    }
  </script>
{{ /push:head }}
```

## Validation

- `vendor/bin/pest`
- `vendor/bin/pint --test src/Http/Controllers/OccurrenceController.php config/statamic-calendar.php tests/Feature/OccurrenceControllerTest.php`
