### PR TITLE
fix: allowlist calendar entry classes for cache unserialization

### DIFF
--- a/src/Occurrences/OccurrenceCache.php
+++ b/src/Occurrences/OccurrenceCache.php
@@ -157,7 +157,8 @@ class OccurrenceCache
                 Event::dispatch($event);
 
                 $occurrences->push([
-                    ...$event->extra,
+                    // toArray() unwraps Arrayable extras; cached payloads stay plain data.
+                    ...collect($event->extra)->toArray(),
                     ...$payload, // Core fields win on collisions.
                 ]);
             }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -41,6 +41,12 @@ class ServiceProvider extends AddonServiceProvider
 
         $this->mergeConfigFrom(__DIR__.'/../config/statamic-calendar.php', 'statamic-calendar');
 
+        // Statamic 6 only unserializes allowlisted classes out of Laravel's cache;
+        // without this, cached Stache entries come back as __PHP_Incomplete_Class.
+        if (method_exists($this, 'registerSerializableClasses')) {
+            $this->registerSerializableClasses([CalendarEntry::class, CalendarEloquentEntry::class]);
+        }
+
         $this->app->singleton(OccurrenceCache::class);
     }
 

--- a/tests/Feature/OccurrenceBuildingEventTest.php
+++ b/tests/Feature/OccurrenceBuildingEventTest.php
@@ -7,6 +7,7 @@ use ElSchneider\StatamicCalendar\Events\OccurrenceBuilding;
 use ElSchneider\StatamicCalendar\Occurrences\Occurrence;
 use ElSchneider\StatamicCalendar\Occurrences\OccurrenceCache;
 use ElSchneider\StatamicCalendar\Occurrences\OccurrenceResolver;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Statamic\Facades\Entry;
@@ -54,7 +55,7 @@ test('rebuild skips unpublished entries', function () {
 
 test('rebuild persists OccurrenceBuilding extras without letting them shadow core fields', function () {
     Event::listen(OccurrenceBuilding::class, function (OccurrenceBuilding $e) {
-        $e->extra['image'] = ['url' => '/assets/foo.jpg'];
+        $e->extra['image'] = new Collection(['url' => '/assets/foo.jpg']);
         $e->extra['category'] = $e->entry->slug();
         $e->extra['occurrence_date'] = $e->occurrence->start->toDateString();
         $e->extra['title'] = 'Shadowed title';

--- a/tests/Feature/SerializableClassesTest.php
+++ b/tests/Feature/SerializableClassesTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use ElSchneider\StatamicCalendar\Entries\CalendarEloquentEntry;
+use ElSchneider\StatamicCalendar\Entries\CalendarEntry;
+use ElSchneider\StatamicCalendar\ServiceProvider;
+use Statamic\Providers\AddonServiceProvider;
+
+it('allowlists the calendar entry classes for cache unserialization', function () {
+    // `false` is the "restricted, nothing allowed yet" marker Statamic 6 apps ship.
+    config()->set('cache.serializable_classes', false);
+
+    (new ServiceProvider(app()))->register();
+
+    expect(config('cache.serializable_classes'))
+        ->toContain(CalendarEntry::class, CalendarEloquentEntry::class);
+})->skip(
+    ! method_exists(AddonServiceProvider::class, 'registerSerializableClasses'),
+    'Statamic 5 has no cache class allowlist.'
+);


### PR DESCRIPTION
Statamic 6 restricts which classes Laravel's cache may unserialize (`cache.serializable_classes`). The addon's entry classes weren't registered, so cached Stache entries came back as `__PHP_Incomplete_Class` and every request failed.

- register `CalendarEntry` / `CalendarEloquentEntry` via `registerSerializableClasses()` (guarded — Statamic 5 has no allowlist)
- unwrap `Arrayable` values from `OccurrenceBuilding` extras so cached payloads stay plain data

Fixes #26
