### PR TITLE
chore: allow testbench 11 and pest 5, refresh npm lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
         "statamic/cms": "^5.74.0 || ^6.20.3"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0 || ^10.0",
-        "pestphp/pest": "^4.3",
-        "pestphp/pest-plugin-laravel": "^4.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "pestphp/pest": "^4.3 || ^5.0",
+        "pestphp/pest-plugin-laravel": "^4.0 || ^5.0",
         "laravel/pint": "^1.27"
     },
     "config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "statamic-calendar",
       "devDependencies": {
         "prettier": "^3.5.0",
         "prettier-plugin-antlers": "^2.0.5"
@@ -14,9 +15,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "statamic-calendar",
   "private": true,
   "scripts": {
     "format:check": "prettier --check .",


### PR DESCRIPTION
Dependency maintenance. Dependabot handles minor/patch updates but ignores majors, so this picks up what it can't.

## Composer

- `orchestra/testbench`: allow `^11.0` (Laravel 13)
- `pestphp/pest` + `pestphp/pest-plugin-laravel`: allow `^5.0`

Old majors stay allowed on purpose — Pest 5 requires PHP 8.4, so the PHP 8.3 CI jobs resolve back to Pest 4 / Testbench 10, as does the Statamic 5 matrix leg. No CI changes needed.

`statamic/cms` and `rlanvin/php-rrule` are already current within their constraints.

## npm

- lockfile: prettier 3.9.4 → 3.9.6
- added `name` to `package.json` so installs from a git worktree stop rewriting the lockfile's `name` field to the directory name

## Verification

Locally on PHP 8.5 with Statamic 6.26 / Laravel 13 / Pest 5: 75 tests passing, Pint clean, Prettier clean. Resolution also re-checked against `statamic/cms:^5.74`.
