### PR TITLE
fix: register calendar entry class on flat-file statamic 6 sites

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Boot">
+            <directory>tests/Boot</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -126,14 +126,6 @@ class ServiceProvider extends AddonServiceProvider
 
     private function registerCalendarEntryClass(): void
     {
-        $collection = Collection::find(config('statamic-calendar.collection', 'events'));
-
-        if ($collection && method_exists($collection, 'entryClass')) {
-            $this->configureCollectionEntryClass($collection);
-
-            return;
-        }
-
         $stockClass = $this->usesEloquentEntries()
             ? \Statamic\Eloquent\Entries\Entry::class
             : \Statamic\Entries\Entry::class;
@@ -142,6 +134,15 @@ class ServiceProvider extends AddonServiceProvider
             return;
         }
 
+        if ($collection = Collection::find(config('statamic-calendar.collection', 'events'))) {
+            $this->configureCollectionEntryClass($collection);
+        }
+
+        // Statamic 6 resolves the entry class off the collection, but flat-file
+        // collections are rehydrated from YAML on every lookup, so the class set
+        // above only survives on drivers that keep the instance (eloquent).
+        // Binding the container class covers the Stache, and Statamic 5, which has
+        // no per-collection entry class at all.
         $entryClass = $this->calendarEntryClass();
         $this->app->bind(EntryContract::class, $entryClass);
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -138,11 +138,8 @@ class ServiceProvider extends AddonServiceProvider
             $this->configureCollectionEntryClass($collection);
         }
 
-        // Statamic 6 resolves the entry class off the collection, but the Stache
-        // hands out collections rebuilt from its own cached item, so the class set
-        // above only survives on drivers that keep the instance (eloquent).
-        // Binding the container class covers the Stache, and Statamic 5, which has
-        // no per-collection entry class at all.
+        // The Stache rebuilds collections from its cached item, so the class set
+        // above only sticks on eloquent. The binding covers Stache and Statamic 5.
         $entryClass = $this->calendarEntryClass();
         $this->app->bind(EntryContract::class, $entryClass);
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -138,8 +138,8 @@ class ServiceProvider extends AddonServiceProvider
             $this->configureCollectionEntryClass($collection);
         }
 
-        // Statamic 6 resolves the entry class off the collection, but flat-file
-        // collections are rehydrated from YAML on every lookup, so the class set
+        // Statamic 6 resolves the entry class off the collection, but the Stache
+        // hands out collections rebuilt from its own cached item, so the class set
         // above only survives on drivers that keep the instance (eloquent).
         // Binding the container class covers the Stache, and Statamic 5, which has
         // no per-collection entry class at all.

--- a/tests/Boot/EntryClassRegistrationTest.php
+++ b/tests/Boot/EntryClassRegistrationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use ElSchneider\StatamicCalendar\Entries\CalendarEntry;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Stache;
+
+beforeEach(function () {
+    config()->set('statamic-calendar.url.strategy', 'date_segments');
+});
+
+test('entries get calendar urls when the collection already existed at boot', function () {
+    Carbon::setTestNow('2026-07-11 12:00:00');
+
+    // Real requests rebuild collections from the persisted Stache, so anything the
+    // addon set on the boot-time instance is gone by the time entries are made.
+    Stache::clear();
+
+    $entry = Entry::make()
+        ->collection(Collection::find('events'))
+        ->locale('default')
+        ->slug('community-meetup')
+        ->data(['dates' => [['start_date' => '2026-07-12', 'start_time' => '18:00']]]);
+
+    expect($entry)->toBeInstanceOf(CalendarEntry::class)
+        ->and($entry->url())->toBe('/calendar/2026/07/12/community-meetup');
+});

--- a/tests/Boot/EntryClassRegistrationTest.php
+++ b/tests/Boot/EntryClassRegistrationTest.php
@@ -15,9 +15,7 @@ beforeEach(function () {
 test('entries get calendar urls when the collection already existed at boot', function () {
     Carbon::setTestNow('2026-07-11 12:00:00');
 
-    // Real requests rebuild collections from the persisted Stache, so anything the
-    // addon set on the boot-time instance is gone by the time entries are made.
-    Stache::clear();
+    Stache::clear(); // force the rehydration a real request does
 
     $entry = Entry::make()
         ->collection(Collection::find('events'))

--- a/tests/ExistingCollectionTestCase.php
+++ b/tests/ExistingCollectionTestCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ElSchneider\StatamicCalendar\Tests;
+
+/**
+ * Boots the app with the events collection already on disk — the state of every
+ * real install, and the one that used to skip calendar URL registration.
+ */
+abstract class ExistingCollectionTestCase extends TestCase
+{
+    private const COLLECTION = __DIR__.'/__fixtures__/content/collections/events.yaml';
+
+    protected function tearDown(): void
+    {
+        @unlink(self::COLLECTION);
+
+        parent::tearDown();
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        @mkdir(dirname(self::COLLECTION), 0755, true);
+        file_put_contents(self::COLLECTION, "title: Events\n");
+    }
+}

--- a/tests/ExistingCollectionTestCase.php
+++ b/tests/ExistingCollectionTestCase.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace ElSchneider\StatamicCalendar\Tests;
 
-/**
- * Boots the app with the events collection already on disk — the state of every
- * real install, and the one that used to skip calendar URL registration.
- */
+/** Events collection exists before boot — the state of every real install. */
 abstract class ExistingCollectionTestCase extends TestCase
 {
     private const COLLECTION = __DIR__.'/__fixtures__/content/collections/events.yaml';

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use ElSchneider\StatamicCalendar\Tests\ExistingCollectionTestCase;
 use ElSchneider\StatamicCalendar\Tests\TestCase;
 
 pest()->extend(TestCase::class)->in('Feature');
+
+// Boot tests need the app booted against content that already exists on disk,
+// so they get their own case instead of building fixtures per test.
+pest()->extend(ExistingCollectionTestCase::class)->in('Boot');


### PR DESCRIPTION
Found while proving v0.5.0 on a fresh Statamic 6 flat-file install: the CP shows neither **Visit URL** nor **Live Preview** on event entries, and entries have no occurrence URL at all.

## Cause

`ServiceProvider::registerCalendarEntryClass()` set the entry class on the collection returned by `Collection::find()` during boot, then returned early. The Stache serves collections rebuilt from its cached item, so that boot-time mutation is gone by the time entries are made, and `Entry::collection()` reads the class only from the collection. Events therefore stayed `Statamic\Entries\Entry`:

- `date_segments` (docs say to leave the collection route unset): `url()` is `null`, so the CP renders neither action
- `query_string`: Visit URL points at the plain entry URL instead of the occurrence

Two setups masked it. The Eloquent driver keeps the collection instance, so the class sticks — that's what the v6 sandbox runs. Statamic 5 has no per-collection entry class, so the old code fell through to the container binding. The test suite masked it too: it runs on the `array` cache, which hands back the same mutated instance, and every test created its collection *after* boot.

## Fix

Check the "site already has a custom entry class" guard first, keep setting the collection entry class for Eloquent, and no longer skip the container binding — that covers the Stache and Statamic 5.

The binding is global, so entries in every collection are now instantiated as `CalendarEntry`. That's the pre-existing Statamic 5 behaviour and it's inert elsewhere: `HasCalendarUrls` delegates to `parent::` unless the entry is in the configured events collection.

## Test

`tests/Boot/` gets its own case that writes the events collection YAML before the app boots — the state of every real install — and clears the Stache before asserting, to force the rehydration a real request does. Fails on `main`, passes here.

## Verification

- full suite green (91), Pint clean
- fresh Statamic 6.26 / Laravel 13 flat-file install, addon symlinked, no `entry_class` in the collection: entry resolves to `CalendarEntry`, `url()` → `/calendar/2026/08/10/weekly-standup`, CP shows both Visit URL and Live Preview, Live Preview renders
- entries in other collections keep byte-identical URLs to v0.5.0 (only the PHP class differs), and their CP Visit URL is unchanged
- Eloquent sandbox re-checked against this branch: entry class, occurrence URL and Live Preview all unchanged
